### PR TITLE
fix(ci): remove push-to-main trigger from ci.yml to prevent concurrency collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   workflow_call:
-  push:
-    branches: [main]
   pull_request:
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Remove `push: branches: [main]` trigger from `ci.yml`

## Why

`ci.yml` is triggered both directly by `push` to main **and** indirectly via `workflow_call` from the publish/release workflow. Both instances share the same concurrency group (`ci-${{ github.ref }}`), so they race — the second one cancels the first. This can cause the entire release pipeline to be canceled on the latest commit with no retry.

Since the publish/release workflow already calls `ci.yml` via `workflow_call` on every push to main, the standalone push trigger is redundant and harmful.

## Test plan

- [ ] Verify PRs still trigger CI (the `pull_request` trigger is unchanged)
- [ ] Verify push to main triggers the publish/release workflow, which runs CI via `workflow_call`
- [ ] Confirm no more "Canceling since a higher priority waiting request" on main branch