### PR TITLE
chore: sync version-tag and crates-publish workflows from REPO_MANIFEST.toml

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -16,5 +16,4 @@ concurrency:
 jobs:
   tag:
     uses: greenticai/.github/.github/workflows/tag-on-version-bump.yml@main
-    secrets:
-      PUSH_TOKEN: ${{ secrets.GH_NIGHTLY_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Syncs weekly-stable caller workflows from `REPO_MANIFEST.toml`.

**Workflows deployed:**
- `tag-on-version-bump.yml` — creates `v*` tag on push to main when Cargo.toml version changes
- `crates-publish.yml` — publishes to crates.io on tag push (crates: `greentic-operator`)

Tier: 4



Source: [REPO_MANIFEST.toml](https://github.com/greenticai/.github/blob/main/toolchain/REPO_MANIFEST.toml)