### PR TITLE
ci(security): guard codex-security-fix against fork PRs

### DIFF
--- a/.github/workflows/codex-security-fix.yml
+++ b/.github/workflows/codex-security-fix.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   security-fix:
+    # Do not run on fork PRs to avoid passing untrusted refs into privileged remediation workflows.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: greenticai/.github/.github/workflows/codex-security-fix.yml@main
     with:
       branch: ${{ github.event.inputs.branch || '' }}


### PR DESCRIPTION
## Summary

P1.7 from release-pipeline audit (`plans/release-pipeline-audit-nightly-dev-weekly-stable.md`).

The `codex-security-fix` workflow has `contents: write` + `pull-requests: write` permissions. Without a fork guard, a fork PR could trick it into running privileged remediation against the attacker's head ref and committing that result back to the base repo.

Add the same guard already present in `greentic-flow`: only run on `pull_request` events where `head.repo.full_name == github.repository`, or on `workflow_dispatch`.

One of 39 PRs rolling this fix across every repo that uses `codex-security-fix.yml`.

## Test plan
- [ ] PR CI green
- [ ] Fork PR test: this workflow should skip (not run remediation)
