### PR TITLE
chore: move Codex security-fix trigger to nightly schedule

### DIFF
--- a/.github/workflows/codex-security-fix.yml
+++ b/.github/workflows/codex-security-fix.yml
@@ -1,7 +1,10 @@
 name: Codex Security Fix
+# Moved off pull_request onto a nightly schedule. See plans/binary-bifurcation.md
+# Phase A.4 (Wave 3). Manual runs remain available via workflow_dispatch.
+
 on:
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "27 5 * * *"
   workflow_dispatch:
     inputs:
       branch:
@@ -23,7 +26,7 @@ concurrency:
 
 jobs:
   security-fix:
-    # Do not run on fork PRs to avoid passing untrusted refs into privileged remediation workflows.
+    # Fork-PR guard kept defense-in-depth; no-op now pull_request is removed.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: greenticai/.github/.github/workflows/codex-security-fix.yml@main
     with:


### PR DESCRIPTION
## Summary

- Flip `codex-security-fix.yml` from `on: pull_request` to `on: schedule` + `workflow_dispatch`
- Cron slot: `27 5 * * *` (05:27 UTC)
- Per `plans/binary-bifurcation.md` Phase A.4 (Wave 3)