### PR TITLE
chore(release): bump to 0.4.49 and align binstall with shared workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "0.4.48"
+version = "0.4.49"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "greentic-operator"
-version = "0.4.48"
+version = "0.4.49"
 edition = "2024"
 rust-version = "1.91"
 description = "Greentic operator CLI for local dev and demo orchestration."
@@ -19,19 +19,17 @@ include = [
 ]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }"
-bin-dir = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.tgz"
 pkg-fmt = "tgz"
-bin = ["greentic-operator"]
-
-[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
-pkg-fmt = "zip"
-
-[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
-pkg-fmt = "zip"
-
-[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
-pkg-fmt = "tgz"
+bin-dir = "{ name }-v{ version }-{ target }/{ bin }{ binary-ext }"
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "aarch64-pc-windows-msvc",
+]
 
 [[bin]]
 name = "greentic-operator"


### PR DESCRIPTION
## Summary

`cargo binstall greentic-operator` will 404 once the next release runs through the shared workflow, because the existing binstall metadata doesn't match what the workflow actually produces.

## What was wrong

| Field | Before | After shared-workflow output |
|---|---|---|
| `pkg-url` order | `{name}-{target}-v{version}.{archive-format}` | `{name}-v{version}-{target}.tgz` |
| `bin-dir` stem | `{name}-{target}-v{version}/...` | `{name}-v{version}-{target}/...` |
| Windows pkg-fmt | override to `zip` | workflow emits `.tgz` (caller doesn't set `windows-archive-format: zip`) |
| `targets` | missing | explicit list for binstall discoverability |

The old v0.4.48 assets happened to match the *old* binstall block (someone previously aligned them), but greenticai/.github#98 standardizes on `{name}-v{version}-{target}.tgz` and non-Windows repos default to `.tgz` across all platforms. This PR pulls greentic-operator in line.

## Changes

- Replace binstall block with the standard ecosystem template (matches greentic-flow / greentic-runner / greentic-dev)
- Drop redundant `bin = [\"greentic-operator\"]` and no-op `aarch64-unknown-linux-gnu` override
- Bump `0.4.48` → `0.4.49`

## Merge order

Blocked on **greenticai/.github#98**.

## Test plan

- [ ] #98 merges
- [ ] Merge this → v0.4.49 release has `greentic-operator-v0.4.49-<target>.tgz` on all 6 targets
- [ ] `cargo binstall greentic-operator` downloads prebuilt (including Windows targets — `.tgz` now, not `.zip`)