### PR TITLE
chore: move nightly cron into 03:XX UTC window (Phase A.7.2)

### DIFF
--- a/.github/workflows/codex-security-fix.yml
+++ b/.github/workflows/codex-security-fix.yml
@@ -4,7 +4,7 @@ name: Codex Security Fix
 
 on:
   schedule:
-    - cron: "27 5 * * *"
+    - cron: "12 3 * * *"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Summary
- Re-crons scheduled nightly workflows into the 03:00-03:59 UTC window per plans/binary-bifurcation.md Phase A.7.2
- Cron-only change; no job logic modified
- Slot assignments follow the fleet-wide allocation (tier-4 repos in 03:10-03:51)

## Changes
- `codex-security-fix.yml`: `27 5 * * *` → `12 3 * * *`

## Test plan
- [x] YAML parse clean (verified locally)
- [x] No other hunks in the diff