### PR TITLE
ci: add scheduled-failure catch-all Slack notifier

### DIFF
--- a/.github/workflows/notify-scheduled-failures.yml
+++ b/.github/workflows/notify-scheduled-failures.yml
@@ -1,0 +1,37 @@
+name: Notify scheduled failures
+
+# Catch-all Slack notifier for scheduled workflow failures. Fires via
+# workflow_run on any workflow completion in this repo; the job-level
+# if: filters to event==schedule and conclusion==failure. This closes
+# the gap where failed nightlies (local reusables, inline sibling jobs,
+# legacy per-repo workflows) used to stay silent because they didn't
+# call notify-failure.yml directly. One file per repo covers every
+# current and future scheduled workflow without per-workflow wiring.
+#
+# Manual (workflow_dispatch) failures stay quiet by design — the
+# operator is already watching when they hit dispatch.
+
+on:
+  workflow_run:
+    # "*" matches every workflow in the repo — that's the point of the
+    # catch-all. GitHub supports glob patterns in `workflows:` and
+    # without this field actionlint emits a schema warning.
+    workflows: ["*"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  notify:
+    if: >-
+      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.conclusion == 'failure'
+    uses: greenticai/.github/.github/workflows/notify-failure.yml@main
+    with:
+      workflow-name: ${{ github.event.workflow_run.name }}
+      repo: ${{ github.repository }}
+      run-url: ${{ github.event.workflow_run.html_url }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a catch-all Slack notifier for scheduled workflow failures, firing via `workflow_run` on any workflow completion in this repo. The job-level `if:` filters to `event == schedule && conclusion == failure`, then calls the shared `notify-failure.yml@main` with `workflow_run.html_url` so the Slack link points at the failed run, not the notifier.

One file per repo covers every current and future scheduled workflow without per-workflow wiring — closes the gap where failed nightlies (local reusables, inline sibling jobs, legacy per-repo workflows) stayed silent because plan A.7.3 only wired `notify-failure` into four shared reusables + four custom nightlies.

Part of option-3 fleet rollout. Shakedown validated in greentic-telemetry#56.

## Test plan

- [x] actionlint clean (locally verified on the shakedown copy).
- [ ] Natural validation: first scheduled failure in this repo after merge should post to `#ci-alerts` with a link pointing at the failed run, not the notifier run.