### PR TITLE
chore: sync dev-publish caller from REPO_MANIFEST.toml

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -8,16 +8,33 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # Stage 1 — tests + version stamping. Outputs the stamped dev version
+  # {M.m.GITHUB_RUN_ID} consumed by binaries + publish.
+  dev-prepare:
+    uses: greenticai/.github/.github/workflows/dev-prepare.yml@main
+    with:
+      exclude-crates: "secret_name greentic-secrets-repro"
+
+  dev-binaries-greentic-operator:
+    needs: dev-prepare
+    uses: greenticai/.github/.github/workflows/dev-release-binaries.yml@main
+    with:
+      package: greentic-operator
+      version: ${{ needs.dev-prepare.outputs.version }}
+
   dev-publish:
+    needs: [dev-prepare, dev-binaries-greentic-operator]
     uses: greenticai/.github/.github/workflows/dev-publish.yml@main
     with:
+      version: ${{ needs.dev-prepare.outputs.version }}
       crates: "greentic-operator"
-      exclude-crates: "secret_name greentic-secrets-repro"
+      binary-crates: "greentic-operator"
+      dual-role-binary-crates: "greentic-operator"
     secrets: inherit


### PR DESCRIPTION
Syncs `dev-publish.yml` caller workflow from `REPO_MANIFEST.toml`.

Crates: `greentic-operator`
Variant: host (tier 4)

Source: [REPO_MANIFEST.toml](https://github.com/greenticai/.github/blob/main/toolchain/REPO_MANIFEST.toml)