### PR TITLE
chore: sync dev-publish caller from REPO_MANIFEST.toml

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -16,18 +16,22 @@ concurrency:
 
 jobs:
   # Stage 1 — tests + version stamping. Outputs the stamped dev version
-  # {M.m.GITHUB_RUN_ID} consumed by binaries + publish.
+  # consumed by binaries + publish. Form is M.m.p-dev.{RUN_ID} for
+  # dual-role repos (require-pre-release: true) so dev library publishes
+  # sort below stable on crates.io; M.m.{RUN_ID} regular release for
+  # binary-only repos (no stable namespace to protect) and pure libraries.
   dev-prepare:
     uses: greenticai/.github/.github/workflows/dev-prepare.yml@main
     with:
       exclude-crates: "secret_name greentic-secrets-repro"
+      require-pre-release: true
 
   dev-binaries-greentic-operator:
     needs: dev-prepare
     uses: greenticai/.github/.github/workflows/dev-release-binaries.yml@main
     with:
       package: greentic-operator
-      version: ${{ needs.dev-prepare.outputs.version }}
+      version: ${{ needs.dev-prepare.outputs.binary-version }}
 
   dev-publish:
     needs: [dev-prepare, dev-binaries-greentic-operator]
@@ -35,6 +39,8 @@ jobs:
     with:
       version: ${{ needs.dev-prepare.outputs.version }}
       crates: "greentic-operator"
+      binary-version: ${{ needs.dev-prepare.outputs.binary-version }}
       binary-crates: "greentic-operator"
       dual-role-binary-crates: "greentic-operator"
+      require-pre-release: true
     secrets: inherit


### PR DESCRIPTION
Syncs `dev-publish.yml` caller workflow from `REPO_MANIFEST.toml`.

Crates: `greentic-operator`
Variant: host (tier 4)

Source: [REPO_MANIFEST.toml](https://github.com/greenticai/.github/blob/main/toolchain/REPO_MANIFEST.toml)