### PR TITLE
chore: bump version 0.5.0-dev.0 → 0.5.0-dev.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ bin = [
 
 [package]
 name = "greentic-operator"
-version = "0.5.0-dev.0"
+version = "0.5.0-dev.1"
 edition = "2024"
 rust-version = "1.91"
 description = "Greentic operator CLI for local dev and demo orchestration."


### PR DESCRIPTION
## Summary
Bumps `[package].version` from `0.5.0-dev.0` to `0.5.0-dev.1` to trigger a fresh `dev-publish` run on develop.

## Why
The currently-published `greentic-operator-dev@0.5.25001436172` (2026-04-27 15:00 UTC) is broken for `cargo binstall`:

```
$ cargo binstall greentic-operator-dev
WARN bin file .../greentic-operator-dev-v.../greentic-operator not found
WARN The package greentic-operator-dev v0.5.25001436172 will be installed from source (with cargo)
```

Root cause: the previous publish ran before the [`rewrite-binary-name.py`](https://github.com/greenticai/.github/pull/134) inline-bin fix landed (2026-04-28 12:21 UTC). The script missed the root-level `bin = [{name = "greentic-operator", ...}]` array — leaving the published `[[bin]].name` as `"greentic-operator"` while the archive ships a binary named `greentic-operator-dev`. Mismatch → binstall falls back to source.

`greentic-operator`'s `dev-publish.yml` only triggers on `push` to develop (no scheduled run), so no fresh publish has happened in the 3 days since the fix. This bump is the trigger.

## Expected outcome
After merge + nightly run:
- `greentic-operator-dev@0.5.{NEW_RUN_ID}` published with `[[bin]].name = "greentic-operator-dev"`
- `cargo binstall greentic-operator-dev` resolves from binaries (no source build)

## Test plan
- [ ] Wait for nightly / push trigger to run dev-publish
- [ ] Verify on crates.io: published `Cargo.toml` shows `[[bin]].name = "greentic-operator-dev"`
- [ ] `cargo binstall greentic-operator-dev` succeeds without source build

## Refs
- greenticai/.github#134 — script fix
- Repro: \`cargo binstall greentic-operator-dev --dry-run\` against current published version