### PR TITLE
chore: sync toolchain config from canonical source

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,5 +4,5 @@
 # Do not edit per-repo.
 
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4023,7 +4023,7 @@ impl DemoSendArgs {
             ));
         }
         let mut arg_entries = args.iter().collect::<Vec<_>>();
-        arg_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        arg_entries.sort_by_key(|(a, _)| *a);
         for (key, value) in arg_entries {
             config_items.push(ConfigGateItem::new(
                 key.as_str(),

--- a/src/gmap/edit.rs
+++ b/src/gmap/edit.rs
@@ -23,7 +23,7 @@ pub fn upsert_policy(path: &Path, rule_path: &str, policy: Policy) -> anyhow::Re
 
     let mut rules = parse_str(&updated)?;
     upsert_rule(&mut rules, rule_path, policy)?;
-    rules.sort_by(|a, b| canonical_key(&a.path).cmp(&canonical_key(&b.path)));
+    rules.sort_by_key(|a| canonical_key(&a.path));
     let rendered = render_rules(&rules);
     write_file(path, &rendered)?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ fn localize_help_text(rendered: &str) -> String {
         }
         pairs.push((en_value, localized.clone()));
     }
-    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    pairs.sort_by_key(|b| std::cmp::Reverse(b.0.len()));
 
     let mut out = rendered.to_string();
     for (from, to) in pairs {


### PR DESCRIPTION
Syncs `rust-toolchain.toml` and `rustfmt.toml` from the canonical source in `greenticai/.github/toolchain/`.

Changes:
- Standardize Rust toolchain to 1.94.0
- Add `rustfmt.toml` with `edition = "2024"`

Source: https://github.com/greenticai/.github/tree/main/toolchain