### PR TITLE
chore(nightly): cargo update (bot)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56676639c1c6248e9e2cda5e0c4b0be0cdf3d23eea16cd296bfb5c59b654689e"
 dependencies = [
  "greentic-interfaces-guest",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "qa-spec",
  "serde",
  "serde_cbor",
@@ -2010,7 +2010,7 @@ dependencies = [
  "camino",
  "directories",
  "greentic-config-types",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "once_cell",
  "serde",
  "serde_json",
@@ -2026,7 +2026,7 @@ version = "1.1.0-dev.25478178810"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6712a75d262243c7ee9bc7b974d4468b32b6ffc84123832fb8559fbd8e093109"
 dependencies = [
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "serde",
  "serde_json",
  "toml 1.1.2+spec-1.1.0",
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-distributor-client"
-version = "1.1.0-dev.25483347672"
+version = "1.1.0-dev.25537586660"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c1977d15033c5eac71bac3f2d9ca4481373a626a67df457d5338d71b2956f6"
+checksum = "7eca60a00e35c61d1d6cf98435be3f7a78f3a06d450ad8ec7d15fb2a010b8019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2046,7 +2046,7 @@ dependencies = [
  "greentic-config-types",
  "greentic-interfaces-guest",
  "greentic-secrets-lib",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "oci-distribution",
  "reqwest 0.13.3",
  "rpassword",
@@ -2075,7 +2075,7 @@ dependencies = [
  "greentic-interfaces-host",
  "greentic-interfaces-wasmtime",
  "greentic-qa-lib",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "handlebars",
  "include_dir",
  "indexmap 2.14.0",
@@ -2121,7 +2121,7 @@ checksum = "0dd1739e0b520fcf8eeb706094e288572a821572a94bdfb10e7c5a68099f9db4"
 dependencies = [
  "anyhow",
  "constant_time_eq 0.4.2",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "semver",
  "thiserror 2.0.18",
  "time",
@@ -2138,7 +2138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31869558530be66ec330013f12e47514d15b8c987c45f72b814c99864d88b833"
 dependencies = [
  "greentic-interfaces",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "wit-bindgen 0.57.1",
  "wit-bindgen-core 0.57.1",
  "wit-bindgen-rust 0.57.1",
@@ -2151,7 +2151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "506adea7c852aca856d14ffef4398de6ada479d1c1340dabfffa528fa580ccc1"
 dependencies = [
  "greentic-interfaces",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "serde",
  "serde_json",
  "wasmtime",
@@ -2196,7 +2196,7 @@ dependencies = [
  "greentic-start",
  "greentic-state",
  "greentic-telemetry 1.1.0-dev.25375809033",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-pack-lib"
-version = "1.1.0-dev.25484598093"
+version = "1.1.0-dev.25537640318"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8eea9a4fd0b6bb4755bcbf5324cdda5c7a3e5e41725fd99740f8eeb3b99f4a"
+checksum = "2a274e56b7f3b6c30063ddac9fc3493bb6df54fd123ae58c78de1dcdfb42bb05"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2241,7 +2241,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
  "greentic-flow",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "hex",
  "indexmap 2.14.0",
  "pkcs8",
@@ -2276,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-desktop"
-version = "1.1.0-dev.25485589875"
+version = "1.1.0-dev.25537657378"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507071b3903d53b7802832c8ce260dd4f6294e34db6f3d09a53905aaf12aecb0"
+checksum = "12bba6fd9ea8c310cf2485b5a78dcc0b07c41e8c0cfaeb2df0cbb15be435148d"
 dependencies = [
  "anyhow",
  "greentic-pack-lib",
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-host"
-version = "1.1.0-dev.25485589875"
+version = "1.1.0-dev.25537657378"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7c1eec01168304af9a330d1cfa9627b54ce427363a43faddc48fb97b84731e"
+checksum = "830579285938cb39668f3dfee612f955f5a501fa918ab81d61fba17bfe8e289c"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2324,7 +2324,7 @@ dependencies = [
  "greentic-session",
  "greentic-state",
  "greentic-telemetry 1.1.0-dev.25375809033",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "handlebars",
  "hex",
  "hmac 0.13.0",
@@ -2462,7 +2462,7 @@ version = "1.1.0-dev.25478208313"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d48f747c12030322701a30878bab74fa88c3a583d9f1681903d81f1d674122e"
 dependencies = [
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "hex",
  "parking_lot",
  "serde_json",
@@ -2485,7 +2485,7 @@ dependencies = [
  "dialoguer",
  "greentic-distributor-client",
  "greentic-secrets-lib",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "hmac 0.13.0",
  "open",
  "qa-spec",
@@ -2524,7 +2524,7 @@ dependencies = [
  "greentic-runner-host",
  "greentic-secrets-lib",
  "greentic-setup",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "hmac 0.13.0",
  "http-body-util",
  "hyper",
@@ -2573,7 +2573,7 @@ checksum = "69804b84951deb6de394de96c1c5cc309f624bef523b97c1f812679b4ed807fa"
 dependencies = [
  "dashmap",
  "greentic-interfaces",
- "greentic-types 1.1.0-dev.25376259391",
+ "greentic-types 1.1.0-dev.25540461571",
  "parking_lot",
  "redis 1.2.1",
  "serde",
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-types"
-version = "1.1.0-dev.25376259391"
+version = "1.1.0-dev.25540461571"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f2d79fd4554b6985d5fd529c88884dec49985c14846bf10b43c9a58ee16e1e"
+checksum = "df38b70a9539e751664e0c3e0a21d6b9ea48e5345d9089d16c5058f122055d30"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2670,7 +2670,7 @@ dependencies = [
  "constant_time_eq 0.4.2",
  "fnv",
  "greentic-telemetry 1.1.0-dev.25375809033",
- "greentic-types-macros 1.1.0-dev.25376259391",
+ "greentic-types-macros 1.1.0-dev.25540461571",
  "indexmap 2.14.0",
  "opentelemetry-otlp",
  "schemars 1.2.1",
@@ -2701,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-types-macros"
-version = "1.1.0-dev.25376259391"
+version = "1.1.0-dev.25540461571"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ab32ec792f065ae49642c15783cd7f513710308f53abf846c8c2f735e9a391"
+checksum = "1b93ebc2d47f7a87e459b9ea80fe9b50d355864c439c9ec6b0b0b3bd02363ac3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4909,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "runner-core"
-version = "1.1.0-dev.25485589875"
+version = "1.1.0-dev.25537657378"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdac34eb47130af7ec2455962ed3aac44fb526e10bace46656f6b8d2d1e8b2df"
+checksum = "9673c9bd3fba6c6859664c0f8ff8bc3354aab940806656b16506f3bda80f24cd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",


### PR DESCRIPTION
Automated nightly `cargo update` — refreshes `Cargo.lock` with the latest
Greentic crate versions published to CodeArtifact earlier in this run.

If auto-merge is queued, this PR will merge once CI passes. If it sits
unmerged, a conflict or failing CI is waiting for manual attention.

Branch is long-lived — subsequent nightlies force-push to it.

— generated by `.github/scripts/nightly-cargo-lock-sync.sh`