### PR TITLE
chore(binstall): standardize on zip for Windows artifacts

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       package: greentic-operator
       binary: greentic-operator
+      windows-archive-format: zip
       extra-files: |
         README.md
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,14 @@ targets = [
   "aarch64-pc-windows-msvc",
 ]
 
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.zip"
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }.zip"
+pkg-fmt = "zip"
+
 [[bin]]
 name = "greentic-operator"
 path = "src/main.rs"


### PR DESCRIPTION
## Summary
- Workflow caller: add `windows-archive-format: zip` so the tag-triggered release-binaries job produces `.zip` for both Windows targets.
- `Cargo.toml`: add `[package.metadata.binstall.overrides.*-pc-windows-msvc]` blocks so `cargo binstall` resolves to `.zip` on Windows.

## Why
Aligns this repo with the fleet-wide convention used by user-facing CLIs and the Rust CLI ecosystem at large.

## Depends on
greenticai/.github#173 (merged) — Compress-Archive wrap-dir fix.

## Test plan
- [ ] Next `v*` tag emits `greentic-operator-v{version}-x86_64-pc-windows-msvc.zip` and the matching aarch64 zip
- [ ] Each zip contains a wrapping `greentic-operator-v{version}-{target}/` directory holding `greentic-operator.exe`
- [ ] `cargo binstall greentic-operator` on Windows resolves the zip