### PR TITLE
chore(cli): drop boundary envelope wrapper now that dispatch_op renders it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,9 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.26043096805"
+version = "1.1.0-dev.26079178340"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bfbab0877888783cba7e2e8d0f554b8a2dfd77b4730e4a9599ba9704731391"
+checksum = "a53ecc0a095c70ea5384f272f09594148328593b9d64fc1b74f78809c11d6dd4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1785,114 +1785,16 @@ impl Cli {
         let ctx = AppCtx {};
         match self.command {
             Command::Demo(demo) => demo.run(&ctx),
-            Command::Op(op) => run_op_command(*op),
+            // `dispatch_op` itself writes the `{op, noun, error: {kind, message}}`
+            // envelope to stderr on failure (greentic-deployer >=1.1.0-dev.26079178340),
+            // so we swallow the `OpError` here and exit 1 directly — letting it
+            // propagate through `anyhow` would print a duplicate plain
+            // `Error: …` line.
+            Command::Op(op) => match greentic_deployer::cli::dispatch::dispatch_op(*op) {
+                Ok(()) => Ok(()),
+                Err(_) => std::process::exit(1),
+            },
         }
-    }
-}
-
-/// Dispatch a `greentic-deployer op …` invocation while preserving the
-/// documented `{op, noun, error: {kind, message}}` envelope on failure.
-/// Without this wrapper an `OpError` would propagate through `anyhow` and
-/// print as plain `Error: …` text, breaking callers that parse stderr for
-/// `error.kind` (idempotency replay, retry logic, etc.).
-fn run_op_command(op: greentic_deployer::cli::dispatch::OpCommand) -> anyhow::Result<()> {
-    let (noun, verb) = op_noun_verb_labels(&op);
-    match greentic_deployer::cli::dispatch::dispatch_op(op) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            let envelope = greentic_deployer::cli::render_error(noun, verb, &err);
-            eprintln!("{envelope}");
-            std::process::exit(1);
-        }
-    }
-}
-
-/// Map an `OpCommand` to its `(noun, verb)` static label pair.
-///
-/// The deployer's `dispatch_op` consumes `cmd.noun` by value and never
-/// hands the labels back, so the operator boundary has to re-derive them
-/// for envelope rendering. Kept in sync with
-/// `greentic-deployer/src/cli/dispatch.rs`.
-fn op_noun_verb_labels(
-    cmd: &greentic_deployer::cli::dispatch::OpCommand,
-) -> (&'static str, &'static str) {
-    use greentic_deployer::cli::dispatch::{
-        BundlesVerb, ConfigVerb, CredentialsVerb, EnvPacksVerb, EnvVerb, OpNoun, RevisionsVerb,
-        SecretsVerb, TrafficVerb,
-    };
-    match &cmd.noun {
-        OpNoun::Env { verb } => (
-            "env",
-            match verb {
-                EnvVerb::Create => "create",
-                EnvVerb::Update => "update",
-                EnvVerb::List => "list",
-                EnvVerb::Show { .. } => "show",
-                EnvVerb::Doctor { .. } => "doctor",
-                EnvVerb::Destroy { .. } => "destroy",
-            },
-        ),
-        OpNoun::EnvPacks { verb } => (
-            "env-packs",
-            match verb {
-                EnvPacksVerb::Add => "add",
-                EnvPacksVerb::Update => "update",
-                EnvPacksVerb::Remove => "remove",
-                EnvPacksVerb::Rollback => "rollback",
-                EnvPacksVerb::List { .. } => "list",
-            },
-        ),
-        OpNoun::Bundles { verb } => (
-            "bundles",
-            match verb {
-                BundlesVerb::Add => "add",
-                BundlesVerb::Update => "update",
-                BundlesVerb::Remove => "remove",
-                BundlesVerb::List { .. } => "list",
-            },
-        ),
-        OpNoun::Revisions { verb } => (
-            "revisions",
-            match verb {
-                RevisionsVerb::Stage => "stage",
-                RevisionsVerb::Warm => "warm",
-                RevisionsVerb::Drain => "drain",
-                RevisionsVerb::Archive => "archive",
-                RevisionsVerb::List { .. } => "list",
-            },
-        ),
-        OpNoun::Traffic { verb } => (
-            "traffic",
-            match verb {
-                TrafficVerb::Set => "set",
-                TrafficVerb::Show => "show",
-                TrafficVerb::Rollback => "rollback",
-            },
-        ),
-        OpNoun::Config { verb } => (
-            "config",
-            match verb {
-                ConfigVerb::Show => "show",
-                ConfigVerb::Set => "set",
-            },
-        ),
-        OpNoun::Credentials { verb } => (
-            "credentials",
-            match verb {
-                CredentialsVerb::Requirements => "requirements",
-                CredentialsVerb::Bootstrap => "bootstrap",
-                CredentialsVerb::Rotate => "rotate",
-            },
-        ),
-        OpNoun::Secrets { verb } => (
-            "secrets",
-            match verb {
-                SecretsVerb::List => "list",
-                SecretsVerb::Put => "put",
-                SecretsVerb::Get => "get",
-                SecretsVerb::Rotate => "rotate",
-            },
-        ),
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to greenticai/greentic-operator#71 and greenticai/greentic-deployer#201. The deployer's \`dispatch_op\` (published as \`greentic-deployer 1.1.0-dev.26079178340\`) now renders the JSON error envelope itself, making the operator-side \`run_op_command\` wrapper and its 90-line \`op_noun_verb_labels\` lookup table redundant — they were producing duplicate envelopes on error.

Replaced with a 3-line match:

\`\`\`rust
match dispatch_op(*op) {
    Ok(()) => Ok(()),
    Err(_) => std::process::exit(1),
}
\`\`\`

The \`Err(_) => exit(1)\` (rather than \`?\`) is still needed so the returned \`OpError\` is swallowed before anyhow renders a duplicate plain \`Error: …\` line — \`dispatch_op\` already wrote the envelope to stderr.

Net diff: **-109 / +11 lines** in \`src/cli.rs\` plus the lockfile bump.

## Why this is safe to ship now (not earlier)

The cleanup couldn't land in #71 because the new \`dispatch_op\` behavior wasn't on crates.io yet. greentic-deployer#201's dev-publish run (\`26079178340\`) succeeded earlier this session at 06:03:18 UTC, so \`>=1.1.0-dev, <1.2.0-0\` now resolves to the right version.

## Tests

The existing \`op_env_show_missing_emits_json_error_envelope\` integration test in \`tests/op_cli.rs\` continues to pass — same contract assertions (stderr is JSON envelope, stdout empty, exit non-zero), now upheld by \`dispatch_op\` rather than the operator's wrapper. It's now a regression guard against the published deployer behavior.

## Verification

- \`cargo update -p greentic-deployer\` → \`1.1.0-dev.26079178340\` (was \`26043096805\`)
- \`bash ci/local_check.sh\` — exit 0
- \`cargo fmt --all --check\` — clean
- \`cargo clippy -p greentic-operator --all-targets -- -D warnings\` — clean
- \`cargo test -p greentic-operator\` — 225 / 225 (unchanged count, simpler implementation)

## Related

- greenticai/greentic-operator#71 — operator wiring (where the wrapper originally landed)
- greenticai/greentic-deployer#201 — moved envelope rendering into \`dispatch_op\`

## Test plan

- [ ] CI green on develop
- [ ] Post-merge smoke: \`gtc op env show missing-env\` → stderr is single-line JSON envelope, stdout empty, exit 1