### PR TITLE
feat(cli): route resolve_env through greentic-setup compat alias (A4b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -278,9 +278,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.14"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -311,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d203b0bf2626dcba8665f5cd0871d7c2c0930223d6b6be9097592fea21242d0"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede2ddc593e6c8acc6ce3358c28d6677a6dc49b65ba4b37a2befe14a11297e75"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.124.0"
+version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744c09d75dfec039a05cf8e117c995ded3b0baffa6eb83f3ed7075a01d8d8947"
+checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -394,23 +394,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "lru 0.16.4",
  "percent-encoding",
  "regex-lite",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.101.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a525ad948df2cc742875ec9b5768c70ba8089564efcef6844ef7c37abdea10"
+checksum = "811bcb3da8bf26e571da7a248c0a93152bba9642aa4c8c907c58d949fa5f1d5c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-signin"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2be50385791aff2768713a88745a6ffd9a79d932ec33d9ca25d9589c75a133"
+checksum = "c6c8ee580b0c24a1e16e63efc2d96d0d0e6f9ecfd397818467d247b628a7cad5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.99.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9acba7c62f3d4e2408fa998a3a8caacd8b9a5b5549cf36e2372fbdae329d5449"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -493,20 +493,20 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.5"
+version = "0.64.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180dddf5ef0f52a2f99e2fada10e16ea610e507ef6148a42bdc4d5867596aa00"
+checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -529,16 +529,16 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.19"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.5"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ccbb08c10f6bcf912f398188e42ee2eab5f1767ce215a02a73bc5df1bbdd95"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -593,27 +593,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -646,11 +646,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.5"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -662,10 +663,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.5"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -689,18 +701,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.3.13"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0470cc047657c6e286346bdf10a8719d26efd6a91626992e0e64481e44323e96"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1586,15 +1598,6 @@ dependencies = [
  "once_cell",
  "phf",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2566,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-config"
-version = "1.1.0-dev.25478178810"
+version = "1.1.0-dev.26092624059"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136630406728b8740d774e0a30dcbd17f845a4f29bb9e51c4c1dadcec6a00086"
+checksum = "e446c47042db504a2cb4ea2f56c14cfd58714b34372e9f6857f1a2268fe804ab"
 dependencies = [
  "anyhow",
  "camino",
@@ -2586,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-config-types"
-version = "1.1.0-dev.25478178810"
+version = "1.1.0-dev.26092624059"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6712a75d262243c7ee9bc7b974d4468b32b6ffc84123832fb8559fbd8e093109"
+checksum = "3c4ac4f31c8e48f07a1b705e5825079f9c6c66404e0aec44efd826cb79fcee02"
 dependencies = [
  "greentic-types 1.1.0-dev.25540461571",
  "serde",
@@ -2599,9 +2602,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.1.0"
+version = "0.1.26088688225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963dbb47b87340ddf2a5db1a214055254eda4343db7863d2712a57d3a4c9aa82"
+checksum = "b6f0c262d1948f2caa9eb58fb1048f2b4d297864bd6aa525e2f30e6ff01f68ce"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -2616,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.26079178340"
+version = "1.1.0-dev.26088688225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53ecc0a095c70ea5384f272f09594148328593b9d64fc1b74f78809c11d6dd4"
+checksum = "df43cc6188393188aec147281c871ff79125ceb10a30377146e53eca8e851837"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3008,7 +3011,7 @@ dependencies = [
  "greentic-secrets-api",
  "greentic-secrets-provider-dev",
  "greentic-secrets-spec",
- "greentic-types 0.5.0",
+ "greentic-types 0.5.2",
  "hkdf",
  "lru 0.17.0",
  "once_cell",
@@ -3035,7 +3038,7 @@ dependencies = [
  "greentic-secrets-core",
  "greentic-secrets-provider-dev",
  "greentic-secrets-spec",
- "greentic-types 0.5.0",
+ "greentic-types 0.5.2",
 ]
 
 [[package]]
@@ -3075,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d3a0df9415b3a1a30001f785e4c7753d0ca83aecd29221b0eb7922a9d824a2"
 dependencies = [
  "async-trait",
- "greentic-types 0.5.0",
+ "greentic-types 0.5.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3098,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-setup"
-version = "1.1.0-dev.26017262957"
+version = "1.1.0-dev.26090926189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2875b615fcf6704100d3fa5d5c7e41b09b0a23e78447e81737d80aef0eb5018d"
+checksum = "e8d7218790b8340369ac374645972a6e5366b550f687d9a7c176b55a1acfe2d7"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -3109,6 +3112,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "dialoguer",
+ "greentic-deployer",
  "greentic-distributor-client",
  "greentic-secrets-lib",
  "greentic-types 1.1.0-dev.25540461571",
@@ -3133,18 +3137,20 @@ dependencies = [
 
 [[package]]
 name = "greentic-start"
-version = "1.1.0-dev.25855801217"
+version = "1.1.0-dev.26090919774"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98bdcc7a3f2a2bd835c4362aea24478043cb9aaf7cb46fb636c78428e411c01"
+checksum = "fff3054ce483bab3f8fb563f9cac2314fa1dea4e3fa6c4927b3a272a4fd7571a"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backhand",
  "base64 0.22.1",
  "chrono",
  "clap",
  "dashmap",
  "flate2",
  "futures-util",
+ "greentic-deployer",
  "greentic-distributor-client",
  "greentic-runner-desktop",
  "greentic-runner-host",
@@ -3212,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-telemetry"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddbd1f4862b4d0e48c68a8fefc24c406edec25b0732ac37a27c6859f6de4d8c"
+checksum = "4f52813e6d9117803d3f1f0eb042beb85d62cee60a46bb22a5489582e22e1e2a"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3226,7 +3232,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-error",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3255,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-types"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415843282d5d62ec500cec793525d28eb576a1ed38cde59e230a6aaf1ba7bcd"
+checksum = "27d3246d833a9d0c3c44694c9381df09df6361754f9590e922bfad0829a6d789"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3265,7 +3270,7 @@ dependencies = [
  "ciborium",
  "constant_time_eq 0.4.2",
  "fnv",
- "greentic-telemetry 0.4.6",
+ "greentic-telemetry 0.5.1",
  "greentic-types-macros 0.5.2",
  "indexmap 2.14.0",
  "opentelemetry-otlp",
@@ -4295,12 +4300,12 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4435,9 +4440,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -6307,12 +6312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6426,9 +6425,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6788,9 +6787,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -6826,19 +6825,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2075,7 +2075,11 @@ impl DemoSetupWizardArgs {
         // 1. Collect answers via card wizard
         let answers = qa_setup_wizard::run_interactive_card_wizard(&self.pack, &provider_id)?;
 
-        // 2. Build input payload with collected answers
+        // 2. Build input payload with collected answers. Resolve the env
+        //    through `greentic_setup::resolve_env` so the wizard payload
+        //    reflects the active environment (defaults to `local` per A4b;
+        //    legacy `dev` is remapped with a once-per-process warn).
+        let env = greentic_setup::resolve_env(None);
         let input = json!({
             "tenant": &self.tenant,
             "team": self.team.as_deref().unwrap_or("default"),
@@ -2084,7 +2088,7 @@ impl DemoSetupWizardArgs {
             "config": { "id": &provider_id },
             "msg": {
                 "id": format!("{provider_id}.setup"),
-                "tenant": { "env": "dev", "tenant": &self.tenant },
+                "tenant": { "env": env, "tenant": &self.tenant },
                 "channel": "setup",
                 "session_id": "setup",
             },

--- a/src/secrets_setup.rs
+++ b/src/secrets_setup.rs
@@ -33,12 +33,11 @@ use crate::{
     secrets_gate::canonical_secret_uri,
 };
 
-pub fn resolve_env(override_env: Option<&str>) -> String {
-    override_env
-        .map(|value| value.to_string())
-        .or_else(|| std::env::var("GREENTIC_ENV").ok())
-        .unwrap_or_else(|| "dev".to_string())
-}
+/// Re-export of [`greentic_setup::resolve_env`] so the operator goes
+/// through the same `dev` → `local` compat alias (A4b PR2) and inherits
+/// the `GREENTIC_DISABLE_DEV_ALIAS` hard-fail gate. Local literal-fallback
+/// duplication was removed in PR4 of A4b.
+pub use greentic_setup::resolve_env;
 
 pub struct SecretsSetup {
     store: DevStore,

--- a/tests/secrets_setup_integration.rs
+++ b/tests/secrets_setup_integration.rs
@@ -130,8 +130,10 @@ fn provider_setup_seeds_and_resolves_secret() -> Result<()> {
     let store_path = dev_store_path::ensure_path(&bundle_root)?;
     assert!(store_path.exists());
     let store = DevStore::with_path(store_path.clone())?;
+    // A4b: `resolve_env(None)` now defaults to `local` (was `dev`); the
+    // seeded URI scope must match.
     let uri = secrets_gate::canonical_secret_uri(
-        "dev",
+        "local",
         "demo",
         Some("default"),
         "messaging-telegram",


### PR DESCRIPTION
## Summary

PR4a of A4b (\`plans/next-gen-deployment.md\`). Operator slice of the \"align remaining dev literals\" cleanup. The setup/start siblings (greenticai/greentic-setup#113, greenticai/greentic-start#164) and the greentic-config flip (greenticai/greentic-config#43) have all landed; this PR routes the operator through the same \`dev\` → \`local\` compat alias rather than carrying its own pre-A4b fallback.

PR4b (\`greentic-secrets-broker\` — CLI default + lib default kind) is the last remaining A4b PR.

## What's in

- \`secrets_setup::resolve_env\` collapses to \`pub use greentic_setup::resolve_env\`. Keeps the call-site API stable (4 in-crate callers continue to import \`crate::secrets_setup::resolve_env\`) while routing through the same compat-alias module: legacy \`dev\` is remapped to \`local\` with a once-per-process \`tracing::warn!\`, and the \`GREENTIC_DISABLE_DEV_ALIAS\` hard-fail gate now applies to the operator binary too.
- \`DemoSetupWizardArgs::run\` (\`cli.rs\`) replaces the hardcoded \`\"env\": \"dev\"\` field in the synthesized wizard payload with \`greentic_setup::resolve_env(None)\`, so the card-wizard flow receives a tenant context matching the actual environment. The previous literal would have silently routed wizard secrets into the \`dev\` env scope regardless of the user's \`--env\` or \`\$GREENTIC_ENV\` value.
- \`tests/secrets_setup_integration::provider_setup_seeds_and_resolves_secret\` updated to assert the \`local\`-scoped URI now produced by the default \`resolve_env(None)\`. Test intent (seed → resolve round-trip via dev-store) preserved; only the env literal flipped.

## Tests

- \`cargo test\` — 161 unit + every integration suite green, including the migrated \`secrets_setup_integration\` test.
- \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- \`cargo fmt --check\` — clean.
- \`bash ci/local_check.sh\` — full gate green (exit 0).

\`Cargo.lock\` refreshed in the same PR (per the binary-bifurcation lockfile rule); picks up \`greentic-setup 1.1.0-dev.26090926189\`, \`greentic-start 1.1.0-dev.26090919774\`, and \`greentic-config 1.1.0-dev.26092624059\` — the post-A4b PR2/PR3 versions.

## Test plan

- [x] \`cargo test\` — all green
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] \`bash ci/local_check.sh\` — full gate green (exit 0)