### PR TITLE
feat(operator): A10 follow-up — env reaches executor and secrets

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1814,6 +1814,44 @@ impl Cli {
 
 struct AppCtx {}
 
+/// RAII guard that scopes a process env-var to a value for the lifetime
+/// of the guard, restoring (or removing) it on drop. A10 follow-up:
+/// used to align `$GREENTIC_ENV` with the canonical wizard env so the
+/// DemoRunner / secrets manager / capability lookups read the value the
+/// user actually passed via `--env` instead of `DemoCommand::run`'s
+/// `"demo"` default.
+struct EnvVarScope {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl EnvVarScope {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = env::var(key).ok();
+        // SAFETY: callers serialize tests + this runs on the binary
+        // entry thread where no other thread is reading the var
+        // concurrently. set_var is unsafe in Rust 2024 edition only
+        // because of multi-threaded racy reads — out of scope here.
+        unsafe {
+            env::set_var(key, value);
+        }
+        Self { key, prior }
+    }
+}
+
+impl Drop for EnvVarScope {
+    fn drop(&mut self) {
+        // SAFETY: see EnvVarScope::set; restoration runs on the same
+        // single-threaded path.
+        unsafe {
+            match &self.prior {
+                Some(value) => env::set_var(self.key, value),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
+}
+
 impl DemoCommand {
     fn run(self, ctx: &AppCtx) -> anyhow::Result<()> {
         if env::var("GREENTIC_ENV").is_err() {
@@ -2094,7 +2132,15 @@ impl DemoSetupWizardArgs {
         //    reflects the active environment (`--env` overrides
         //    `$GREENTIC_ENV`; defaults to `local` per A4b; legacy `dev`
         //    is remapped with a once-per-process warn).
+        //
+        //    A10 follow-up: scope $GREENTIC_ENV to the canonical value
+        //    around the DemoRunner invocation. Closes the split-brain
+        //    where the payload's `msg.tenant.env` said `local` but
+        //    secrets manager / runner host config read $GREENTIC_ENV
+        //    (defaulted to "demo" by DemoCommand::run L1819). RAII
+        //    guard restores the prior value on every exit path.
         let env = greentic_setup::resolve_env(Some(&self.env));
+        let _env_scope = EnvVarScope::set("GREENTIC_ENV", &env);
         let input = json!({
             "tenant": &self.tenant,
             "team": self.team.as_deref().unwrap_or("default"),
@@ -2163,6 +2209,16 @@ impl DemoWizardArgs {
         let mode: wizard::WizardMode = self.mode.into();
         let effective_locale = self.locale.clone().unwrap_or_else(detect_system_locale_tag);
         let schema_version = resolve_wizard_schema_version(self.schema_version.as_deref());
+        // A10 follow-up: canonicalize env once so both the QA wizard
+        // flow and the run-setup executor see the same env id; without
+        // this, --apply / --run-setup falls back to $GREENTIC_ENV
+        // (defaulted to "demo" by DemoCommand::run) and writes/reads
+        // secrets under the wrong env. Scope $GREENTIC_ENV around the
+        // whole flow so any remaining indirect readers (capability
+        // resolvers, config_gate, plan executors that call
+        // resolve_env(None)) observe the canonical value too.
+        let canonical_env = resolve_env(Some(&self.env));
+        let _env_scope = EnvVarScope::set("GREENTIC_ENV", &canonical_env);
         let provider_registry_ref = self
             .provider_registry
             .clone()
@@ -2209,7 +2265,7 @@ impl DemoWizardArgs {
                 run_wizard_via_qa(
                     mode,
                     &effective_locale,
-                    &resolve_env(Some(&self.env)),
+                    &canonical_env,
                     prefilled_answers,
                     &qa_provider_labels,
                     self.verbose,
@@ -2537,6 +2593,7 @@ impl DemoWizardArgs {
                     &plan.bundle,
                     &tenant.tenant,
                     tenant.team.as_deref(),
+                    &canonical_env,
                     self.setup_input.as_ref(),
                     allowed_providers.clone(),
                     preloaded_setup_answers.clone(),
@@ -3835,6 +3892,7 @@ fn run_wizard_setup_for_target(
     bundle: &Path,
     tenant: &str,
     team: Option<&str>,
+    env: &str,
     setup_input: Option<&PathBuf>,
     allowed_providers: Option<BTreeSet<String>>,
     preloaded_setup_answers: Option<SetupInputAnswers>,
@@ -3860,7 +3918,7 @@ fn run_wizard_setup_for_target(
             allow_contract_change: false,
             backup: false,
             online: false,
-            secrets_env: None,
+            secrets_env: Some(env.to_string()),
             runner_binary: None,
             best_effort: true,
             discovered_providers: None,


### PR DESCRIPTION
## Summary

Closes **both** Codex adversarial-review high findings on [`#75`](https://github.com/greenticai/greentic-operator/pull/75):

1. **`DemoWizardArgs::run` built `WizardCreateRequest` without `self.env`** — the `--apply` / `--run-setup` executor downstream (`run_wizard_setup_for_target` → `DomainRunArgs` → `run_plan_item` → `resolve_env(secrets_env)`) fell back to `$GREENTIC_ENV` (defaulted to `"demo"` by `DemoCommand::run` L1819). `--env prod` was wizard-only.
2. **`DemoSetupWizardArgs::run` split brain** — env resolved into the JSON payload's `msg.tenant.env` but the DemoRunner / secrets manager / capability lookups inside the runner stack read `$GREENTIC_ENV` independently. Payload said `local`, runner ran under `demo`.

## What changes

- **New `EnvVarScope` RAII guard** — snapshots a process env-var on `set()`, restores (or removes) on drop. Used to scope `$GREENTIC_ENV` around the wizard flow so any indirect reader (capability resolver, config_gate, plan executor that calls `resolve_env(None)`) observes the canonical value. Codex called this out explicitly: *"set and restore a scoped `GREENTIC_ENV` around this invocation"*.
- **`DemoWizardArgs::run`**:
  - Resolve `self.env` once into `canonical_env` at the top.
  - Scope `$GREENTIC_ENV = canonical_env` for the rest of the function via `EnvVarScope`.
  - Pass `&canonical_env` to the existing `run_wizard_via_qa` call.
  - Pass `&canonical_env` to the new `run_wizard_setup_for_target` signature so `DomainRunArgs.secrets_env` carries it into the executor.
- **`DemoSetupWizardArgs::run`**:
  - Same `EnvVarScope` for the DemoRunner block. Payload's `msg.tenant.env` and the runner's runtime env now match.
- **`run_wizard_setup_for_target`** gains an `env: &str` parameter and sets `secrets_env: Some(env.to_string())` on every domain's `DomainRunArgs` (was hardcoded `None`).

## What does NOT change

- **DemoRunner / HostConfig signatures unchanged.** The runtime env reaches the runner via `$GREENTIC_ENV` (the scope guard) rather than a new typed parameter — that refactor is broader than the surgical fix scope.
- **Pre-existing `resolve_env(None)` call sites** at L5703 and L5878 now observe the scoped canonical value through `$GREENTIC_ENV`; no code change needed there.

## Test plan

- [x] `cargo test --workspace` green (40+ result lines, all OK).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.

Refs: Codex review task `bf2uo71hg`; #75 (parent); plan row A10.
