### PR TITLE
feat(docker): C4 — distroless musl-static image (greentic-operator)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target
+.git
+.github
+dist
+tmp
+node_modules

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+#
+# C4 (Phase A): musl-static binary on a distroless nonroot base.
+# Default base is gcr.io/distroless/static-debian12:nonroot (uid 65532, no
+# shell, ships ca-certificates); Chainguard is the optional hardened upgrade.
+
+FROM rust:1.95-bookworm AS build
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    musl-tools \
+    build-essential \
+    cmake \
+    perl \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+ENV CC_x86_64_unknown_linux_musl=musl-gcc
+ENV CXX_x86_64_unknown_linux_musl=g++
+ENV CARGO_TARGET_DIR=/tmp/target
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/tmp/target \
+    cargo build --release --target x86_64-unknown-linux-musl \
+    --config 'profile.release.strip=true' --bin greentic-operator \
+    && mkdir -p /out \
+    && cp /tmp/target/x86_64-unknown-linux-musl/release/greentic-operator /out/greentic-operator
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/greentic-operator /usr/local/bin/greentic-operator
+
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/greentic-operator"]


### PR DESCRIPTION
## Summary

C4 (Phase A, cross-cutting — distroless + MUSL + non-root) for `greentic-operator`. Adds a `Dockerfile.distroless` (none existed) following the proven `greentic-start` pattern, plus a `.dockerignore`.

- Multi-stage build: `rust:1.95-bookworm` build stage produces a **musl-static** `greentic-operator` binary (`x86_64-unknown-linux-musl`); runtime stage is **`gcr.io/distroless/static-debian12:nonroot`** (plan default; Chainguard deferred until a subscription lands, plan line 1607).
- `static-debian12` bundles ca-certificates + a uid-65532 nonroot user and has no shell — no apt runtime layer needed.
- **Symbols stripped** via `profile.release.strip` (cargo `--config`). Unstripped, the image was **31.62 MB** — over the C4 <30MB gate; stripped it is **27.33 MB**. (The sibling deployer/start images get the same strip for consistency + headroom.)
- `COPY . .` brings in the full workspace (i18n catalogs, `secret_name`, `crates/greentic-secrets-repro`); `.dockerignore` keeps `target`, `.git`, etc. out of the build context.

### Verification (built locally)

```
image size      27.33 MB      (< 30 MB gate ✓)
Config.User     65532:65532   ✓
binary          statically linked (ldd), static-pie (file)  ✓
```

Refs: `plans/next-gen-deployment.md` row C4; cross-cutting gate C4.
