### PR TITLE
chore(deps): bump greentic-deployer pin to pick up C3 `op env tool-check` verb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.26149398477"
+version = "1.1.0-dev.26164962162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b349523a814b9d59d73202ac85d0eac52c6d16f3436783bdae6b114fac9ac43a"
+checksum = "6a23aa8bc11f609b5432d3df477240666065e042745f67fdca9fa8dd5610c0b7"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary

- Operator's `Cargo.lock` was last touched by A10 (#75) on 2026-05-20, pinning `greentic-deployer 1.1.0-dev.26149398477` — published *before* C3 #217 landed the `tool-check` env-verb in deployer.
- Latest published `greentic-operator-dev` (v1.1.26164960311) was rebuilt against this stale pin via `--locked` and therefore shipped without the verb.
- End users see `error: unrecognized subcommand 'tool-check'` from `greentic-operator-dev op env`.
- gtc's `op` router is correct (greenticai/greentic#225 verified the prepend-`op` behavior); the failure is purely operator-side lockfile lag.

## Fix

Surgical `cargo update -p greentic-deployer@1.1.0-dev.26149398477 --precise 1.1.0-dev.26164962162` — pulls in the post-C3 publish (#217 `tool-check` + #218 `/simplify`). 2-line `Cargo.lock` change.

## Test plan

- [x] `cargo build --locked` ✓
- [x] `bash ci/local_check.sh` ✓ (full test suite + binstall artifact)
- [x] Locally-rebuilt `./target/debug/greentic-operator op env --help` now lists `tool-check` alongside `init`/`create`/`destroy`/etc.
- [ ] Next nightly republishes `greentic-operator-dev` with the verb present.
