### PR TITLE
fix: bump greentic-deployer for op deploy noun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2191,7 +2191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2655,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.1.26494839672"
+version = "0.1.26597245002"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13525bee2a21bb58661acf7a327a9ea9a5c567ad32e75930892cbb89fda3823"
+checksum = "dccd77c612adfdd5f6f6adca5bdb85a28050a82c166549ec605fc8e5d5199f1e"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -2674,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.26494839672"
+version = "1.1.0-dev.26597245002"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00af52fa39d3d00241d6e0df030cc50ded06b7a2cb3af1b9e899bcdb01fede9d"
+checksum = "8595effd5306ffc976a5ca8a35864fac64e730c78b023986f9f489adc80e0819"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4468,7 +4468,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5762,7 +5762,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5854,7 +5854,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6522,7 +6522,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7979,7 +7979,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -740,6 +740,7 @@ mod tests {
                 env_id: demo_env_id(),
                 region: None,
                 tenant_org_id: None,
+                listen_addr: None,
             },
             packs: Vec::new(),
             credentials_ref: None,


### PR DESCRIPTION
## Problem

`gtc op deploy` returns `unrecognized subcommand 'deploy'` even after publishing the new greentic-deployer (#234).

Root cause: `op deploy` is **compiled into** greentic-operator — the operator embeds the deployer's command tree via `Op(Box<greentic_deployer::cli::dispatch::OpCommand>)` (`cli.rs:91`) and dispatches through `dispatch_op` (`cli.rs:1807`). The committed `Cargo.lock` pinned the pre-#234 deployer (`1.1.0-dev.26494839672`), so the built/published operator binary had no `deploy` arm in its clap enum. Bumping greentic-deployer alone is not enough — the **operator** must be recompiled against it.

## Change

- `cargo update --precise` bumps `greentic-deployer` and its co-published `greentic-deploy-spec` to `*.26597245002` (the publish containing #234).
- The new `greentic-deploy-spec` adds `EnvironmentHostConfig.listen_addr: Option<SocketAddr>`; set it to `None` (→ `DEFAULT_LISTEN_ADDR` via `resolved_listen_addr()`) in the one test helper that constructs the struct literally.

## Verification

- `./target/debug/greentic-operator op deploy --help` now prints the one-shot deploy usage.
- `bash ci/local_check.sh` → exit 0 (fmt, clippy, i18n, 185+ tests, binstall package all green).