### PR TITLE
fix(deployments): set messaging_endpoints in test Environment literal

### DIFF
--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -747,6 +747,7 @@ mod tests {
             bundles: Vec::new(),
             revisions: vec![rev],
             traffic_splits: Vec::new(),
+            messaging_endpoints: Vec::new(),
             revocation: Default::default(),
             retention: Default::default(),
             health: Default::default(),


### PR DESCRIPTION
## What

Adds the missing `messaging_endpoints: Vec::new()` field to the `env_with_one_revision` test helper in `src/deployments/api.rs`.

## Why

`greentic-deploy-spec` gained `Environment.messaging_endpoints: Vec<MessagingEndpoint>` (Phase M1). Once the field-bearing dev crate (`0.1.26628825486`) was published, operator's `develop` failed to compile because this struct literal didn't set the new field:

```
error[E0063]: missing field `messaging_endpoints` in initializer of `greentic_deploy_spec::Environment`
   --> src/deployments/api.rs:735:9
```

This broke the nightly dev-publish (tier 8): https://github.com/greenticai/.github/actions/runs/26739859162

## Notes

- The field is `#[serde(default)]`, so on-disk deserialization is unaffected; this is purely a struct-literal construction gap in test code.
- Test env has no endpoints → empty `Vec` is correct.
- No `Cargo.lock` bump needed: `develop`'s lock already pins the field-bearing `greentic-deploy-spec 0.1.26628825486`.

## Verification

```
cargo check --tests -p greentic-operator        # clean (built against 0.1.26628825486)
cargo clippy -p greentic-operator --all-targets --all-features -- -D warnings   # clean
```