### PR TITLE
[codex] add generic capability runtime event bindings

### DIFF
--- a/.codex/done/PR-OP-capability-runtime-events.md
+++ b/.codex/done/PR-OP-capability-runtime-events.md
@@ -1,0 +1,339 @@
+# PR: Add generic capability bindings and local pub/sub delivery to Operator
+
+## Summary
+
+Extend the existing `greentic-operator` local/runtime capability path so any
+Greentic pack/runtime can request and offer named capabilities through Operator.
+SORLA, SORX, and OPERALA are the immediate consumers, but the implementation
+must not encode those runtime names or business domains into core Operator
+types, storage paths, command behavior, or matching rules.
+
+This PR should not re-add the generic capability registry or basic capability
+invocation. Those already exist:
+
+- `src/capabilities.rs` loads `greentic.ext.capabilities.v1` offers from pack
+  manifests into `CapabilityRegistry`.
+- `DemoRunnerHost::invoke_capability` resolves capability offers and invokes the
+  selected provider component/op.
+- the current demo command tree already exposes
+  `capability list|invoke|setup-plan|mark-ready|mark-failed`.
+- the current setup flow already logs capability bootstrap expectations for
+  messaging, events, secrets, OAuth, and MCP.
+- this repo already has generic state-layout/catalog groundwork:
+  `src/state_layout.rs` writes under `state/capabilities/...`, and
+  `src/capability_runtime.rs` writes `callables.json`, `subscriptions.json`,
+  and `topics.json` for the current tenant/team scope.
+
+Instead, add the missing generic layer: callable capability bindings,
+topic/subscription bindings, deterministic resolved artifacts, and local pub/sub
+delivery with audit, retry, and replay.
+
+## Current state
+
+Operator is still presented in the repo as demo/local operations tooling, not a
+general production control plane. The README says it orchestrates demos and local
+development, while runtime lifecycle is delegated to `greentic-start`.
+
+There are production-facing pieces in the codebase:
+
+- top-level `op ...` in this binary delegates to `greentic-deployer`, and the
+  current `op` noun set is still deployment-focused (`env`, `env-packs`,
+  `bundles`, `revisions`, `traffic`, `config`, `credentials`, `secrets`)
+- HTTP ingress exposes deployment lifecycle routes under `/deployments`
+- runtime state can use Redis via capability bootstrap
+- `demo start` can run embedded gateway/egress/subscriptions without legacy GSM
+
+This PR should keep the first implementation compatible with the existing
+bundle-backed local runtime surface. The data model and command design
+should be generic enough for a future production Operator to reuse unchanged,
+but this PR should not claim that Operator is already a full production runtime
+fabric.
+
+It also should not assume this repo can mint new top-level `op` nouns by
+itself. If the final UX wants `gtc op capability ...` or
+`gtc op subscriptions ...`, that command-surface work must be coordinated with
+the deployer-owned `op` dispatch rather than treated as a local-only rename.
+
+## Motivation
+
+Greentic runtimes need a shared local contract for:
+
+- one pack/runtime offering callable functions
+- another pack/runtime requiring those functions without knowing the concrete pack/op
+- packs/runtimes publishing typed events
+- packs/runtimes subscribing handlers to those events
+
+Operator already owns the local bundle boundary: pack discovery, tenant/team
+scope, `.gmap`, resolved manifests, secrets gating, provider invocation, ingress,
+subscriptions, and event routing. It is the right place to bind generic
+capability intent to concrete pack operations in local deployments.
+
+## Genericity requirements
+
+- Core types must use neutral names such as `CallableCapability`,
+  `CapabilityRequirement`, `EventTopic`, `EventSubscription`, and
+  `DeliveryBinding`.
+- Do not name core structs, paths, extensions, or command flags after SORLA,
+  SORX, OPERALA, invoices, approvals, or any other specific domain.
+- Domain-specific examples may appear only in tests/fixtures/docs as examples.
+- Matching must be based on capability id, operation id, topic/event type,
+  schema/version, scope, priority, and policy, not on runtime identity.
+- Adapters must be extensible through an enum/trait boundary. Initial adapters
+  can include direct provider component invocation and HTTP compatibility.
+- Storage paths must be domain-neutral, for example `state/capabilities/...`,
+  not `state/business/...`.
+- The same mechanism must work for business workflows, system capabilities,
+  integration capabilities, and future Greentic runtimes.
+
+## Existing implementation to preserve
+
+Do not replace these pieces:
+
+- `CapabilityRegistry`, `CapabilityOfferRecord`, `CapabilityBinding`
+- `greentic.ext.capabilities.v1` manifest extension loading
+- scope matching by env/tenant/team
+- priority/stable-id ordering for deterministic offer selection
+- setup-required install records under operator state
+- pre/post hook capability evaluation
+- `DemoRunnerHost::invoke_provider_op` and `invoke_provider_component_op`
+- provider-managed subscription behavior:
+  - existing local implementation remains available for compatibility
+  - any future canonical `gtc op subscriptions ...` surface must be added via
+    deployer-coordinated `op` dispatch; in this repo the currently implemented
+    commands remain `demo subscriptions ensure|status|renew|delete`
+- existing HTTP ingress route:
+  `/v1/{domain}/ingress/{provider}/{tenant}/{team?}/{handler?}`
+- current event routing fallback to the default app flow
+
+## Proposed additions
+
+### Generic capability metadata
+
+Extend the capability manifest model, or add a sibling extension, to describe
+callable and event semantics on top of the existing provider component/op
+binding.
+
+Example shape:
+
+```yaml
+capability_bindings:
+  callables:
+    - capability_id: cap://example.domain.action.v1
+      operation: perform_action
+      input_schema_ref: schemas/action.in.schema.json
+      output_schema_ref: schemas/action.out.schema.json
+      provider:
+        component_ref: provider_component
+        op: perform_action
+      adapter: direct_component
+  events:
+    - topic: topic://example.domain.event.v1
+      event_type: domain.event.v1
+      payload_schema_ref: schemas/event.schema.json
+      publisher:
+        component_ref: provider_component
+        op: publish_event
+```
+
+The exact serialization can be adjusted to match `greentic-types`, but the data
+must compile into existing `CapabilityBinding`/provider-op routing instead of
+creating a parallel invocation stack.
+
+### Resolved binding artifacts
+
+During a capability resolution/export step, or from setup/build flows that need
+resolved capability state, resolve requirements and consumes against offers and
+write deterministic artifacts:
+
+```text
+state/capabilities/<tenant>/<team>/callables.json
+state/capabilities/<tenant>/<team>/subscriptions.json
+state/capabilities/<tenant>/<team>/topics.json
+```
+
+Each callable binding should include:
+
+- requested capability id
+- selected offer stable id
+- pack id and pack path
+- provider component ref
+- provider op
+- adapter kind
+- input/output schema refs or hashes
+- env/tenant/team scope used for selection
+
+Each subscription binding should include:
+
+- subscription id
+- topic/event type
+- subscriber pack id
+- subscriber handler op
+- filter expression, if any
+- schema ref/hash
+- delivery policy
+
+Current code note: `callables.json` is already populated from resolved offers,
+while `subscriptions.json` and `topics.json` are currently written as empty
+placeholders. This PR should extend those existing artifacts instead of
+introducing a second catalog location.
+
+### Generic invocation command
+
+Add a higher-level CLI wrapper over the existing capability invocation path.
+In this repo, that should land first under the existing demo surface, with any
+top-level `op` alias handled separately through deployer-owned dispatch.
+
+Implemented local shape in this repo:
+
+```bash
+gtc demo capability call \
+  --bundle demo-bundle \
+  --cap-id cap://example.domain.action.v1 \
+  --operation perform_action \
+  --input-json '{"id":"example"}' \
+  --tenant demo \
+  --team default
+```
+
+This command should:
+
+1. load the resolved callable binding
+2. validate input against the declared schema when available
+3. call `DemoRunnerHost::invoke_capability` or the selected provider op
+4. validate output when available
+5. print a structured success/error result
+
+Keep `demo capability invoke` as the lower-level debug command.
+
+For the first implementation, `--bundle` selects the local bundle-backed
+runtime backend. If a top-level `gtc op capability ...` alias is desired, treat
+it as follow-on command-surface work that spans this repo and the deployer
+dispatch layer.
+
+### Local event bus
+
+Add a local, bundle-backed event bus for runtime use.
+
+Required behavior:
+
+1. accept a `CapabilityEventEnvelope`
+2. validate topic/event type and payload schema when available
+3. find matching resolved subscriptions
+4. apply filters
+5. invoke subscriber handler ops through the existing runner host
+6. append publish and delivery records to JSONL audit logs
+7. write failed deliveries to a JSONL DLQ
+8. support replay from audit/DLQ by event id or delivery id
+
+Initial storage can be JSONL under:
+
+```text
+state/capabilities/<tenant>/<team>/events.jsonl
+state/capabilities/<tenant>/<team>/deliveries.jsonl
+state/capabilities/<tenant>/<team>/dlq.jsonl
+```
+
+Do not make NATS or remote Operator required for this PR. They can become
+additional adapters later.
+
+### Event publish and debug commands
+
+Add commands under a generic capability namespace rather than expanding the
+runtime-specific surface with many loosely related subcommands. In this repo,
+that means extending the existing `demo capability ...` tree first. The
+implemented command surface keeps the existing `demo capability list` noun and
+adds generic subtrees for subscriptions and events:
+
+```bash
+gtc demo capability list --bundle demo-bundle --tenant demo --team default
+gtc demo capability call --bundle demo-bundle --cap-id cap://... --operation perform_action --input-json '{}'
+gtc demo capability subscriptions list --bundle demo-bundle --tenant demo --team default
+gtc demo capability events publish --bundle demo-bundle --topic topic://... --input-json '{}'
+gtc demo capability events tail --bundle demo-bundle --tenant demo --team default
+gtc demo capability events dlq --bundle demo-bundle --tenant demo --team default
+gtc demo capability events replay --bundle demo-bundle --event-id evt_123
+```
+
+Provider-managed transport subscriptions can also grow from the existing demo
+surface first:
+
+```bash
+gtc demo subscriptions ensure --bundle demo-bundle ...
+gtc demo subscriptions status --bundle demo-bundle ...
+gtc demo subscriptions renew --bundle demo-bundle ...
+gtc demo subscriptions delete --bundle demo-bundle ...
+```
+
+If a future `gtc op subscriptions ...` surface is added, it should be framed as
+a cross-repo alias/dispatch addition, not as something this PR can complete in
+`greentic-operator` alone.
+
+### HTTP compatibility
+
+HTTP ingress remains supported through the existing universal ingress path.
+
+This PR may add an HTTP adapter kind for capability bindings, but it
+should be a compatibility adapter, not the primary local path. The preferred
+local path is direct provider component/op invocation through `DemoRunnerHost`.
+
+## Out of scope
+
+- Replacing `CapabilityRegistry`.
+- Replacing provider-managed subscription renewal.
+- Moving unrelated `demo` commands to production command names.
+- Hard-coding SORLA/SORX/OPERALA-specific behavior.
+- Hard-coding invoice, approval, CRM, or any other vertical workflow.
+- Cross-tenant capability grants.
+- Distributed durable bus as the default implementation.
+- NATS as a required runtime dependency.
+- Remote Operator federation.
+- Removing HTTP ingress or adapter compatibility.
+
+## Acceptance criteria
+
+- Existing capability commands and tests continue to pass.
+- Existing `demo capability list` export and `state/capabilities/...` artifacts
+  continue to work, with `subscriptions.json` / `topics.json` graduating from
+  placeholders to resolved data.
+- Any pack can offer a callable capability in manifest metadata.
+- Another pack/runtime requirement can resolve to that callable for a tenant/team
+  scope.
+- Operator writes deterministic resolved callable/topic/subscription artifacts.
+- The first implemented command surface in this repo calls the selected
+  function through the existing runner host path, even if a future `gtc op`
+  alias is added elsewhere.
+- Any provider/runtime event can be published into the local event bus.
+- A matching subscription handler is invoked.
+- Delivery success/failure is recorded in JSONL audit logs.
+- Failed delivery replay works from the local DLQ.
+- HTTP compatibility remains available and covered by regression tests.
+
+## Test plan
+
+- Unit tests for generic metadata parsing and deterministic binding ordering.
+- Golden tests for resolved `callables.json`, `subscriptions.json`, and
+  `topics.json`.
+- Integration test: one pack offers a callable capability and another pack
+  requires it; Operator resolves and invokes through `DemoRunnerHost`.
+- Integration test: generic event publish invokes a subscribed handler.
+- Schema validation tests for invalid function input and invalid event payload.
+- DLQ/replay test with an intentionally failing subscriber handler.
+- Regression test for the implemented `demo capability ...` surface, plus any
+  later `op`-level alias if dispatch wiring is added in the same change.
+- Regression test for HTTP ingress compatibility.
+
+## Implementation notes
+
+This PR is implemented in `greentic-operator` with:
+
+- generic catalog export in `src/capability_runtime.rs`
+- capability event publish/audit/DLQ/replay in `src/capability_events.rs`
+- manifest parsing for callable/topic/subscription metadata in
+  `src/capabilities.rs`
+- local runtime command wiring under `demo capability ...`
+
+Verification is partially blocked by an upstream dependency mismatch in the
+current workspace graph (`greentic-runner-host` from Cargo registry expects a
+newer `greentic-types` surface). Formatting completed successfully, and the new
+code is scoped so it can be reviewed independently of that unrelated compile
+break.

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -77,8 +77,44 @@ pub struct CapabilityOfferRecord {
     pub priority: i32,
     pub requires_setup: bool,
     pub setup_qa_ref: Option<String>,
+    pub operation_id: Option<String>,
+    pub input_schema_ref: Option<String>,
+    pub output_schema_ref: Option<String>,
+    pub adapter_kind: Option<String>,
     scope: CapabilityScopeV1,
     pub applies_to_ops: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityTopicRecord {
+    pub topic: String,
+    pub event_type: String,
+    pub pack_id: String,
+    pub domain: Domain,
+    pub pack_path: PathBuf,
+    pub publisher_component_ref: String,
+    pub publisher_op: String,
+    pub payload_schema_ref: Option<String>,
+    pub adapter_kind: Option<String>,
+    pub priority: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilitySubscriptionRecord {
+    pub subscription_id: String,
+    pub topic: String,
+    pub event_type: String,
+    pub pack_id: String,
+    pub domain: Domain,
+    pub pack_path: PathBuf,
+    pub capability_id: String,
+    pub op: String,
+    pub payload_schema_ref: Option<String>,
+    pub filter_json_pointer: Option<String>,
+    pub filter_equals: Option<String>,
+    pub delivery_mode: String,
+    pub max_attempts: u32,
+    pub priority: i32,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -129,6 +165,10 @@ impl CapabilityRegistry {
                         priority: offer.priority,
                         requires_setup: offer.requires_setup,
                         setup_qa_ref,
+                        operation_id: offer.operation_id,
+                        input_schema_ref: offer.input_schema_ref,
+                        output_schema_ref: offer.output_schema_ref,
+                        adapter_kind: offer.adapter_kind,
                         scope: offer.scope.unwrap_or_default(),
                         applies_to_ops,
                     });
@@ -151,6 +191,23 @@ impl CapabilityRegistry {
             .get(cap_id)
             .map(Vec::as_slice)
             .unwrap_or_default()
+    }
+
+    pub fn offers_in_scope(&self, scope: &ResolveScope) -> Vec<CapabilityOfferRecord> {
+        let mut selected = Vec::new();
+        for offers in self.by_cap_id.values() {
+            for offer in offers {
+                if scope_matches(&offer.scope, scope) {
+                    selected.push(offer.clone());
+                }
+            }
+        }
+        selected.sort_by(|a, b| {
+            a.priority
+                .cmp(&b.priority)
+                .then_with(|| a.stable_id.cmp(&b.stable_id))
+        });
+        selected
     }
 
     pub fn resolve(
@@ -259,6 +316,91 @@ impl CapabilityRegistry {
 
         warnings
     }
+}
+
+pub fn collect_event_bindings_for_packs(
+    pack_index: &BTreeMap<PathBuf, CapabilityPackRecord>,
+    scope: &ResolveScope,
+) -> anyhow::Result<(
+    Vec<CapabilityTopicRecord>,
+    Vec<CapabilitySubscriptionRecord>,
+)> {
+    let mut topics = Vec::new();
+    let mut subscriptions = Vec::new();
+
+    for (pack_path, pack_record) in pack_index {
+        let Some(ext) = read_capabilities_extension(pack_path)? else {
+            continue;
+        };
+
+        for topic in ext.topics {
+            if !scope_matches(&topic.scope.unwrap_or_default(), scope) {
+                continue;
+            }
+            topics.push(CapabilityTopicRecord {
+                topic: topic.topic,
+                event_type: topic.event_type,
+                pack_id: pack_record.pack_id.clone(),
+                domain: pack_record.domain,
+                pack_path: pack_path.clone(),
+                publisher_component_ref: topic.publisher.component_ref,
+                publisher_op: topic.publisher.op,
+                payload_schema_ref: topic.payload_schema_ref,
+                adapter_kind: topic.adapter_kind,
+                priority: topic.priority,
+            });
+        }
+
+        for subscription in ext.subscriptions {
+            if !scope_matches(&subscription.scope.unwrap_or_default(), scope) {
+                continue;
+            }
+            subscriptions.push(CapabilitySubscriptionRecord {
+                subscription_id: subscription.subscription_id,
+                topic: subscription.topic,
+                event_type: subscription.event_type,
+                pack_id: pack_record.pack_id.clone(),
+                domain: pack_record.domain,
+                pack_path: pack_path.clone(),
+                capability_id: subscription.subscriber.capability_id,
+                op: subscription.subscriber.op,
+                payload_schema_ref: subscription.payload_schema_ref,
+                filter_json_pointer: subscription
+                    .filter
+                    .as_ref()
+                    .and_then(|value| value.json_pointer.clone()),
+                filter_equals: subscription.filter.and_then(|value| value.equals),
+                delivery_mode: subscription
+                    .delivery
+                    .as_ref()
+                    .and_then(|value| value.mode.clone())
+                    .unwrap_or_else(|| "at_least_once".to_string()),
+                max_attempts: subscription
+                    .delivery
+                    .as_ref()
+                    .and_then(|value| value.max_attempts)
+                    .unwrap_or(1),
+                priority: subscription.priority,
+            });
+        }
+    }
+
+    topics.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then_with(|| a.topic.cmp(&b.topic))
+            .then_with(|| a.event_type.cmp(&b.event_type))
+            .then_with(|| a.pack_id.cmp(&b.pack_id))
+    });
+    subscriptions.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then_with(|| a.topic.cmp(&b.topic))
+            .then_with(|| a.subscription_id.cmp(&b.subscription_id))
+            .then_with(|| a.pack_id.cmp(&b.pack_id))
+    });
+
+    Ok((topics, subscriptions))
 }
 
 pub fn is_oauth_broker_operation(op_name: &str) -> bool {
@@ -443,6 +585,10 @@ struct CapabilitiesExtensionV1 {
     schema_version: u32,
     #[serde(default)]
     offers: Vec<CapabilityOfferV1>,
+    #[serde(default)]
+    topics: Vec<CapabilityTopicV1>,
+    #[serde(default)]
+    subscriptions: Vec<CapabilitySubscriptionV1>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -462,6 +608,14 @@ struct CapabilityOfferV1 {
     setup: Option<CapabilitySetupV1>,
     #[serde(default)]
     applies_to: Option<HookAppliesToV1>,
+    #[serde(default)]
+    operation_id: Option<String>,
+    #[serde(default)]
+    input_schema_ref: Option<String>,
+    #[serde(default)]
+    output_schema_ref: Option<String>,
+    #[serde(default)]
+    adapter_kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -489,6 +643,61 @@ struct CapabilitySetupV1 {
 struct HookAppliesToV1 {
     #[serde(default)]
     op_names: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityTopicV1 {
+    topic: String,
+    event_type: String,
+    publisher: CapabilityProviderRefV1,
+    #[serde(default)]
+    payload_schema_ref: Option<String>,
+    #[serde(default)]
+    adapter_kind: Option<String>,
+    #[serde(default)]
+    priority: i32,
+    #[serde(default)]
+    scope: Option<CapabilityScopeV1>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilitySubscriptionV1 {
+    subscription_id: String,
+    topic: String,
+    event_type: String,
+    subscriber: CapabilitySubscriberRefV1,
+    #[serde(default)]
+    payload_schema_ref: Option<String>,
+    #[serde(default)]
+    filter: Option<CapabilityFilterV1>,
+    #[serde(default)]
+    delivery: Option<CapabilityDeliveryV1>,
+    #[serde(default)]
+    priority: i32,
+    #[serde(default)]
+    scope: Option<CapabilityScopeV1>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilitySubscriberRefV1 {
+    capability_id: String,
+    op: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityFilterV1 {
+    #[serde(default)]
+    json_pointer: Option<String>,
+    #[serde(default)]
+    equals: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapabilityDeliveryV1 {
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    max_attempts: Option<u32>,
 }
 
 const fn default_schema_version() -> u32 {
@@ -593,6 +802,10 @@ mod tests {
                     priority: 0,
                     requires_setup: false,
                     setup_qa_ref: None,
+                    operation_id: None,
+                    input_schema_ref: None,
+                    output_schema_ref: None,
+                    adapter_kind: None,
                     scope: CapabilityScopeV1::default(),
                     applies_to_ops: vec![OAUTH_OP_INITIATE_AUTH.to_string()],
                 },
@@ -608,6 +821,10 @@ mod tests {
                     priority: 1,
                     requires_setup: false,
                     setup_qa_ref: None,
+                    operation_id: None,
+                    input_schema_ref: None,
+                    output_schema_ref: None,
+                    adapter_kind: None,
                     scope: CapabilityScopeV1::default(),
                     applies_to_ops: vec![OAUTH_OP_AWAIT_RESULT.to_string()],
                 },
@@ -624,6 +841,95 @@ mod tests {
             )
             .expect("should resolve");
         assert_eq!(resolved.provider_op, "provider.await");
+    }
+
+    #[test]
+    fn offers_in_scope_filters_and_sorts_matching_offers() {
+        let mut by_cap_id = BTreeMap::new();
+        by_cap_id.insert(
+            "cap.example".to_string(),
+            vec![
+                CapabilityOfferRecord {
+                    stable_id: "offer.dev.b".to_string(),
+                    pack_id: "pack".to_string(),
+                    domain: Domain::Messaging,
+                    pack_path: PathBuf::from("/tmp/b.gtpack"),
+                    cap_id: "cap.example".to_string(),
+                    version: "1".to_string(),
+                    provider_component_ref: "provider".to_string(),
+                    provider_op: "op.b".to_string(),
+                    priority: 2,
+                    requires_setup: false,
+                    setup_qa_ref: None,
+                    operation_id: None,
+                    input_schema_ref: None,
+                    output_schema_ref: None,
+                    adapter_kind: None,
+                    scope: CapabilityScopeV1 {
+                        envs: vec!["dev".to_string()],
+                        tenants: Vec::new(),
+                        teams: Vec::new(),
+                    },
+                    applies_to_ops: Vec::new(),
+                },
+                CapabilityOfferRecord {
+                    stable_id: "offer.dev.a".to_string(),
+                    pack_id: "pack".to_string(),
+                    domain: Domain::Messaging,
+                    pack_path: PathBuf::from("/tmp/a.gtpack"),
+                    cap_id: "cap.example".to_string(),
+                    version: "1".to_string(),
+                    provider_component_ref: "provider".to_string(),
+                    provider_op: "op.a".to_string(),
+                    priority: 1,
+                    requires_setup: false,
+                    setup_qa_ref: None,
+                    operation_id: None,
+                    input_schema_ref: None,
+                    output_schema_ref: None,
+                    adapter_kind: None,
+                    scope: CapabilityScopeV1 {
+                        envs: vec!["dev".to_string()],
+                        tenants: Vec::new(),
+                        teams: Vec::new(),
+                    },
+                    applies_to_ops: Vec::new(),
+                },
+                CapabilityOfferRecord {
+                    stable_id: "offer.prod".to_string(),
+                    pack_id: "pack".to_string(),
+                    domain: Domain::Messaging,
+                    pack_path: PathBuf::from("/tmp/prod.gtpack"),
+                    cap_id: "cap.example".to_string(),
+                    version: "1".to_string(),
+                    provider_component_ref: "provider".to_string(),
+                    provider_op: "op.prod".to_string(),
+                    priority: 0,
+                    requires_setup: false,
+                    setup_qa_ref: None,
+                    operation_id: None,
+                    input_schema_ref: None,
+                    output_schema_ref: None,
+                    adapter_kind: None,
+                    scope: CapabilityScopeV1 {
+                        envs: vec!["prod".to_string()],
+                        tenants: Vec::new(),
+                        teams: Vec::new(),
+                    },
+                    applies_to_ops: Vec::new(),
+                },
+            ],
+        );
+        let registry = CapabilityRegistry { by_cap_id };
+        let scope = ResolveScope {
+            env: Some("dev".to_string()),
+            tenant: None,
+            team: None,
+        };
+        let offers = registry.offers_in_scope(&scope);
+        assert_eq!(offers.len(), 2);
+        assert_eq!(offers[0].stable_id, "offer.dev.a");
+        assert_eq!(offers[1].stable_id, "offer.dev.b");
     }
 
     #[test]
@@ -676,6 +982,38 @@ mod tests {
                 .len(),
             1,
             "oauth discovery capability offer missing from registry"
+        );
+    }
+
+    #[test]
+    fn event_bindings_load_from_capabilities_extension() {
+        let tmp = tempdir().expect("tempdir");
+        let pack_path = tmp.path().join("event-provider.gtpack");
+        write_gtpack_with_event_bindings(&pack_path).expect("write pack");
+
+        let mut pack_index = BTreeMap::new();
+        pack_index.insert(
+            pack_path.clone(),
+            CapabilityPackRecord {
+                pack_id: "event.provider".to_string(),
+                domain: Domain::Events,
+            },
+        );
+
+        let (topics, subscriptions) =
+            collect_event_bindings_for_packs(&pack_index, &ResolveScope::default())
+                .expect("event bindings");
+
+        assert_eq!(topics.len(), 1);
+        assert_eq!(subscriptions.len(), 1);
+        assert_eq!(topics[0].topic, "topic://example.domain.event.v1");
+        assert_eq!(
+            subscriptions[0].capability_id,
+            "cap://example.subscriber.v1"
+        );
+        assert_eq!(
+            subscriptions[0].filter_json_pointer.as_deref(),
+            Some("/kind")
         );
     }
 
@@ -758,6 +1096,69 @@ mod tests {
         Ok(())
     }
 
+    fn write_gtpack_with_event_bindings(path: &Path) -> anyhow::Result<()> {
+        let mut extensions = BTreeMap::new();
+        extensions.insert(
+            EXT_CAPABILITIES_V1.to_string(),
+            ExtensionRef {
+                kind: EXT_CAPABILITIES_V1.to_string(),
+                version: "1.0.0".to_string(),
+                digest: None,
+                location: None,
+                inline: Some(greentic_types::ExtensionInline::Other(json!({
+                    "schema_version": 1,
+                    "offers": [],
+                    "topics": [
+                        {
+                            "topic": "topic://example.domain.event.v1",
+                            "event_type": "example.domain.event.v1",
+                            "publisher": {"component_ref": "events.component", "op": "events.publish"},
+                            "payload_schema_ref": "schemas/event.schema.json",
+                            "priority": 10
+                        }
+                    ],
+                    "subscriptions": [
+                        {
+                            "subscription_id": "sub.example",
+                            "topic": "topic://example.domain.event.v1",
+                            "event_type": "example.domain.event.v1",
+                            "subscriber": {"capability_id": "cap://example.subscriber.v1", "op": "handle"},
+                            "payload_schema_ref": "schemas/event.schema.json",
+                            "filter": {"json_pointer": "/kind", "equals": "match"},
+                            "delivery": {"mode": "at_least_once", "max_attempts": 2},
+                            "priority": 20
+                        }
+                    ]
+                }))),
+            },
+        );
+
+        let manifest = PackManifest {
+            schema_version: "pack-v1".to_string(),
+            pack_id: PackId::new("event.provider").expect("pack id"),
+            name: None,
+            version: Version::parse("0.1.0").expect("version"),
+            kind: PackKind::Provider,
+            publisher: "demo".to_string(),
+            components: Vec::new(),
+            flows: Vec::new(),
+            dependencies: Vec::new(),
+            capabilities: Vec::new(),
+            secret_requirements: Vec::new(),
+            signatures: PackSignatures::default(),
+            bootstrap: None,
+            extensions: Some(extensions),
+        };
+
+        let bytes = greentic_types::encode_pack_manifest(&manifest)?;
+        let file = File::create(path)?;
+        let mut zip = ZipWriter::new(file);
+        zip.start_file("manifest.cbor", FileOptions::<()>::default())?;
+        zip.write_all(&bytes)?;
+        zip.finish()?;
+        Ok(())
+    }
+
     // -- Messaging capability tests --
 
     fn make_messaging_offer(
@@ -778,6 +1179,10 @@ mod tests {
             priority: 100,
             requires_setup,
             setup_qa_ref: setup_qa_ref.map(String::from),
+            operation_id: None,
+            input_schema_ref: None,
+            output_schema_ref: None,
+            adapter_kind: None,
             scope: CapabilityScopeV1::default(),
             applies_to_ops: Vec::new(),
         }

--- a/src/capability_events.rs
+++ b/src/capability_events.rs
@@ -1,0 +1,688 @@
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, anyhow};
+use jsonschema::validate;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
+use zip::ZipArchive;
+
+use crate::capability_runtime::{ResolvedSubscriptionRecord, ResolvedTopicRecord};
+use crate::demo::runner_host::{DemoRunnerHost, FlowOutcome, OperatorContext};
+use crate::state_layout;
+
+pub trait CapabilityEventRunner {
+    fn invoke_capability(
+        &self,
+        cap_id: &str,
+        op: &str,
+        payload_bytes: &[u8],
+        ctx: &OperatorContext,
+    ) -> Result<FlowOutcome>;
+}
+
+impl CapabilityEventRunner for DemoRunnerHost {
+    fn invoke_capability(
+        &self,
+        cap_id: &str,
+        op: &str,
+        payload_bytes: &[u8],
+        ctx: &OperatorContext,
+    ) -> Result<FlowOutcome> {
+        DemoRunnerHost::invoke_capability(self, cap_id, op, payload_bytes, ctx)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CapabilityEventEnvelope {
+    pub event_id: String,
+    pub topic: String,
+    pub event_type: String,
+    pub payload: JsonValue,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub published_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PublishEventRequest {
+    pub topic: String,
+    pub event_type: Option<String>,
+    pub payload: JsonValue,
+    pub correlation_id: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityDeliveryRecord {
+    pub delivery_id: String,
+    pub event_id: String,
+    pub subscription_id: String,
+    pub capability_id: String,
+    pub op: String,
+    pub status: String,
+    pub attempts: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub delivered_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CapabilityDeadLetterRecord {
+    pub delivery_id: String,
+    pub event: CapabilityEventEnvelope,
+    pub subscription_id: String,
+    pub capability_id: String,
+    pub op: String,
+    pub attempts: u32,
+    pub error: String,
+    pub failed_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PublishReport {
+    pub matched_subscriptions: usize,
+    pub successful_deliveries: usize,
+    pub failed_deliveries: usize,
+}
+
+pub fn publish_event(
+    bundle_root: &Path,
+    runner: &impl CapabilityEventRunner,
+    ctx: &OperatorContext,
+    topics: &[ResolvedTopicRecord],
+    subscriptions: &[ResolvedSubscriptionRecord],
+    request: PublishEventRequest,
+) -> Result<PublishReport> {
+    publish_event_internal(
+        bundle_root,
+        runner,
+        ctx,
+        topics,
+        subscriptions,
+        request,
+        None,
+        None,
+    )
+}
+
+pub fn replay_event(
+    bundle_root: &Path,
+    runner: &impl CapabilityEventRunner,
+    ctx: &OperatorContext,
+    topics: &[ResolvedTopicRecord],
+    subscriptions: &[ResolvedSubscriptionRecord],
+    event_id: Option<&str>,
+    delivery_id: Option<&str>,
+) -> Result<PublishReport> {
+    let delivery = if let Some(id) = delivery_id {
+        Some(
+            read_jsonl::<CapabilityDeadLetterRecord>(&dlq_path(
+                bundle_root,
+                &ctx.tenant,
+                ctx.team.as_deref(),
+            ))?
+            .into_iter()
+            .find(|item| item.delivery_id == id)
+            .ok_or_else(|| anyhow!("dlq delivery {id} not found"))?,
+        )
+    } else {
+        None
+    };
+
+    let envelope = if let Some(item) = delivery.as_ref() {
+        item.event.clone()
+    } else if let Some(id) = event_id {
+        read_jsonl::<CapabilityEventEnvelope>(&events_path(
+            bundle_root,
+            &ctx.tenant,
+            ctx.team.as_deref(),
+        ))?
+        .into_iter()
+        .find(|item| item.event_id == id)
+        .ok_or_else(|| anyhow!("event {id} not found"))?
+    } else {
+        anyhow::bail!("either event_id or delivery_id is required for replay");
+    };
+
+    let subscription_filter = delivery.as_ref().map(|item| item.subscription_id.as_str());
+    let delivery_id_filter = delivery.as_ref().map(|item| item.delivery_id.as_str());
+    publish_event_internal(
+        bundle_root,
+        runner,
+        ctx,
+        topics,
+        subscriptions,
+        PublishEventRequest {
+            topic: envelope.topic,
+            event_type: Some(envelope.event_type),
+            payload: envelope.payload,
+            correlation_id: envelope.correlation_id,
+            source: envelope.source,
+        },
+        subscription_filter,
+        delivery_id_filter,
+    )
+}
+
+pub fn read_events(
+    bundle_root: &Path,
+    tenant: &str,
+    team: Option<&str>,
+) -> Result<Vec<CapabilityEventEnvelope>> {
+    read_jsonl(&events_path(bundle_root, tenant, team))
+}
+
+pub fn read_dead_letters(
+    bundle_root: &Path,
+    tenant: &str,
+    team: Option<&str>,
+) -> Result<Vec<CapabilityDeadLetterRecord>> {
+    read_jsonl(&dlq_path(bundle_root, tenant, team))
+}
+
+fn publish_event_internal(
+    bundle_root: &Path,
+    runner: &impl CapabilityEventRunner,
+    ctx: &OperatorContext,
+    topics: &[ResolvedTopicRecord],
+    subscriptions: &[ResolvedSubscriptionRecord],
+    request: PublishEventRequest,
+    only_subscription_id: Option<&str>,
+    replay_delivery_id: Option<&str>,
+) -> Result<PublishReport> {
+    let topic = topics
+        .iter()
+        .find(|item| {
+            item.topic == request.topic
+                && request
+                    .event_type
+                    .as_ref()
+                    .map(|value| value == &item.event_type)
+                    .unwrap_or(true)
+        })
+        .ok_or_else(|| anyhow!("topic {} is not defined in current scope", request.topic))?;
+
+    if let Some(schema_ref) = topic.payload_schema_ref.as_deref() {
+        validate_schema(&topic.pack_path, schema_ref, &request.payload)
+            .with_context(|| format!("invalid event payload for topic {}", topic.topic))?;
+    }
+
+    let envelope = CapabilityEventEnvelope {
+        event_id: replay_delivery_id
+            .map(|value| format!("replay-{value}"))
+            .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        topic: topic.topic.clone(),
+        event_type: topic.event_type.clone(),
+        payload: request.payload,
+        correlation_id: request.correlation_id,
+        source: request.source,
+        published_at_unix_ms: now_unix_ms(),
+    };
+    append_jsonl(
+        &events_path(bundle_root, &ctx.tenant, ctx.team.as_deref()),
+        &envelope,
+    )?;
+
+    let matched: Vec<_> = subscriptions
+        .iter()
+        .filter(|item| {
+            item.topic == envelope.topic
+                && item.event_type == envelope.event_type
+                && only_subscription_id
+                    .map(|value| value == item.subscription_id)
+                    .unwrap_or(true)
+                && matches_filter(item, &envelope.payload)
+        })
+        .cloned()
+        .collect();
+
+    let mut report = PublishReport {
+        matched_subscriptions: matched.len(),
+        successful_deliveries: 0,
+        failed_deliveries: 0,
+    };
+
+    let payload_bytes = serde_json::to_vec(&envelope.payload)?;
+
+    for subscription in matched {
+        if let Some(schema_ref) = subscription.payload_schema_ref.as_deref() {
+            validate_schema(&subscription.pack_path, schema_ref, &envelope.payload).with_context(
+                || {
+                    format!(
+                        "invalid payload for subscription {}",
+                        subscription.subscription_id
+                    )
+                },
+            )?;
+        }
+
+        let mut attempts = 0u32;
+        let mut final_error = None;
+        let max_attempts = subscription.max_attempts.max(1);
+        while attempts < max_attempts {
+            attempts += 1;
+            let outcome = runner.invoke_capability(
+                &subscription.capability_id,
+                &subscription.op,
+                &payload_bytes,
+                ctx,
+            )?;
+            if outcome.success {
+                let record = CapabilityDeliveryRecord {
+                    delivery_id: Uuid::new_v4().to_string(),
+                    event_id: envelope.event_id.clone(),
+                    subscription_id: subscription.subscription_id.clone(),
+                    capability_id: subscription.capability_id.clone(),
+                    op: subscription.op.clone(),
+                    status: "ok".to_string(),
+                    attempts,
+                    error: None,
+                    delivered_at_unix_ms: now_unix_ms(),
+                };
+                append_jsonl(
+                    &deliveries_path(bundle_root, &ctx.tenant, ctx.team.as_deref()),
+                    &record,
+                )?;
+                report.successful_deliveries += 1;
+                final_error = None;
+                break;
+            }
+            final_error = Some(
+                outcome
+                    .error
+                    .unwrap_or_else(|| "capability invocation failed".to_string()),
+            );
+        }
+
+        if let Some(error) = final_error {
+            let delivery_id = Uuid::new_v4().to_string();
+            let record = CapabilityDeliveryRecord {
+                delivery_id: delivery_id.clone(),
+                event_id: envelope.event_id.clone(),
+                subscription_id: subscription.subscription_id.clone(),
+                capability_id: subscription.capability_id.clone(),
+                op: subscription.op.clone(),
+                status: "err".to_string(),
+                attempts: max_attempts,
+                error: Some(error.clone()),
+                delivered_at_unix_ms: now_unix_ms(),
+            };
+            append_jsonl(
+                &deliveries_path(bundle_root, &ctx.tenant, ctx.team.as_deref()),
+                &record,
+            )?;
+            append_jsonl(
+                &dlq_path(bundle_root, &ctx.tenant, ctx.team.as_deref()),
+                &CapabilityDeadLetterRecord {
+                    delivery_id,
+                    event: envelope.clone(),
+                    subscription_id: subscription.subscription_id,
+                    capability_id: subscription.capability_id,
+                    op: subscription.op,
+                    attempts: max_attempts,
+                    error,
+                    failed_at_unix_ms: now_unix_ms(),
+                },
+            )?;
+            report.failed_deliveries += 1;
+        }
+    }
+
+    Ok(report)
+}
+
+fn matches_filter(subscription: &ResolvedSubscriptionRecord, payload: &JsonValue) -> bool {
+    let Some(pointer) = subscription.filter_json_pointer.as_deref() else {
+        return true;
+    };
+    let Some(expected) = subscription.filter_equals.as_deref() else {
+        return true;
+    };
+    payload
+        .pointer(pointer)
+        .and_then(|value| value.as_str())
+        .map(|value| value == expected)
+        .unwrap_or(false)
+}
+
+fn validate_schema(pack_path: &str, schema_ref: &str, payload: &JsonValue) -> Result<()> {
+    let schema = load_schema(pack_path, schema_ref)?;
+    validate(&schema, payload).map_err(|err| anyhow!("{err}"))
+}
+
+fn load_schema(pack_path: &str, schema_ref: &str) -> Result<JsonValue> {
+    let path = Path::new(pack_path);
+    if path.is_dir() {
+        let schema_path = path.join(schema_ref);
+        let bytes = fs::read(&schema_path)
+            .with_context(|| format!("failed to read schema {}", schema_path.display()))?;
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse schema {}", schema_path.display()));
+    }
+
+    let file = fs::File::open(path)?;
+    let mut archive = ZipArchive::new(file)?;
+    let mut entry = archive
+        .by_name(schema_ref)
+        .with_context(|| format!("schema {schema_ref} missing in {}", path.display()))?;
+    let mut bytes = Vec::new();
+    entry.read_to_end(&mut bytes)?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse schema {schema_ref} in {}", path.display()))
+}
+
+fn append_jsonl<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(&mut file, value)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn read_jsonl<T: DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut items = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        items.push(serde_json::from_str(trimmed)?);
+    }
+    Ok(items)
+}
+
+fn events_path(root: &Path, tenant: &str, team: Option<&str>) -> std::path::PathBuf {
+    state_layout::capability_state_path(root, tenant, team, "events.jsonl")
+}
+
+fn deliveries_path(root: &Path, tenant: &str, team: Option<&str>) -> std::path::PathBuf {
+    state_layout::capability_state_path(root, tenant, team, "deliveries.jsonl")
+}
+
+fn dlq_path(root: &Path, tenant: &str, team: Option<&str>) -> std::path::PathBuf {
+    state_layout::capability_state_path(root, tenant, team, "dlq.jsonl")
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::tempdir;
+    use zip::ZipWriter;
+    use zip::write::FileOptions;
+
+    #[derive(Default)]
+    struct FakeRunner {
+        fail_capability: Option<String>,
+        invocations: std::sync::Mutex<Vec<(String, String)>>,
+    }
+
+    impl CapabilityEventRunner for FakeRunner {
+        fn invoke_capability(
+            &self,
+            cap_id: &str,
+            op: &str,
+            _payload_bytes: &[u8],
+            _ctx: &OperatorContext,
+        ) -> Result<FlowOutcome> {
+            self.invocations
+                .lock()
+                .expect("invocations lock")
+                .push((cap_id.to_string(), op.to_string()));
+            let success = self.fail_capability.as_deref() != Some(cap_id);
+            Ok(FlowOutcome {
+                success,
+                output: None,
+                raw: None,
+                error: if success {
+                    None
+                } else {
+                    Some("boom".to_string())
+                },
+                mode: crate::demo::runner_host::RunnerExecutionMode::Exec,
+            })
+        }
+    }
+
+    #[test]
+    fn publish_event_writes_logs_and_invokes_subscriber() -> Result<()> {
+        let tmp = tempdir()?;
+        let pack_path = write_schema_pack(tmp.path(), "schemas/event.schema.json")?;
+        let runner = FakeRunner::default();
+        let ctx = OperatorContext {
+            tenant: "tenant-a".to_string(),
+            team: Some("team-b".to_string()),
+            correlation_id: None,
+        };
+        let topics = vec![ResolvedTopicRecord {
+            topic: "topic://example.domain.event.v1".to_string(),
+            event_type: "example.domain.event.v1".to_string(),
+            pack_id: "pack-a".to_string(),
+            domain: "events".to_string(),
+            pack_path: pack_path.display().to_string(),
+            publisher_component_ref: "publisher".to_string(),
+            publisher_op: "publish".to_string(),
+            payload_schema_ref: Some("schemas/event.schema.json".to_string()),
+            adapter_kind: crate::capability_runtime::CapabilityAdapterKind::DirectComponent,
+            priority: 10,
+            scope: crate::capability_runtime::ResolvedScopeRecord {
+                env: None,
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        }];
+        let subscriptions = vec![ResolvedSubscriptionRecord {
+            subscription_id: "sub-a".to_string(),
+            topic: "topic://example.domain.event.v1".to_string(),
+            event_type: "example.domain.event.v1".to_string(),
+            pack_id: "pack-b".to_string(),
+            domain: "events".to_string(),
+            pack_path: pack_path.display().to_string(),
+            capability_id: "cap://subscriber.handle.v1".to_string(),
+            op: "handle".to_string(),
+            payload_schema_ref: None,
+            filter_json_pointer: Some("/kind".to_string()),
+            filter_equals: Some("match".to_string()),
+            delivery_mode: "at_least_once".to_string(),
+            max_attempts: 2,
+            priority: 10,
+            scope: crate::capability_runtime::ResolvedScopeRecord {
+                env: None,
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        }];
+
+        let report = publish_event(
+            tmp.path(),
+            &runner,
+            &ctx,
+            &topics,
+            &subscriptions,
+            PublishEventRequest {
+                topic: "topic://example.domain.event.v1".to_string(),
+                event_type: None,
+                payload: serde_json::json!({"kind":"match"}),
+                correlation_id: None,
+                source: Some("test".to_string()),
+            },
+        )?;
+
+        assert_eq!(report.matched_subscriptions, 1);
+        assert_eq!(report.successful_deliveries, 1);
+        assert_eq!(report.failed_deliveries, 0);
+        assert_eq!(
+            read_events(tmp.path(), "tenant-a", Some("team-b"))?.len(),
+            1
+        );
+        assert_eq!(
+            read_dead_letters(tmp.path(), "tenant-a", Some("team-b"))?.len(),
+            0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn failed_delivery_goes_to_dlq_and_replays() -> Result<()> {
+        let tmp = tempdir()?;
+        let pack_path = write_schema_pack(tmp.path(), "schemas/event.schema.json")?;
+        let failing_runner = FakeRunner {
+            fail_capability: Some("cap://subscriber.handle.v1".to_string()),
+            ..Default::default()
+        };
+        let ctx = OperatorContext {
+            tenant: "tenant-a".to_string(),
+            team: Some("team-b".to_string()),
+            correlation_id: None,
+        };
+        let topics = vec![ResolvedTopicRecord {
+            topic: "topic://example.domain.event.v1".to_string(),
+            event_type: "example.domain.event.v1".to_string(),
+            pack_id: "pack-a".to_string(),
+            domain: "events".to_string(),
+            pack_path: pack_path.display().to_string(),
+            publisher_component_ref: "publisher".to_string(),
+            publisher_op: "publish".to_string(),
+            payload_schema_ref: Some("schemas/event.schema.json".to_string()),
+            adapter_kind: crate::capability_runtime::CapabilityAdapterKind::DirectComponent,
+            priority: 10,
+            scope: crate::capability_runtime::ResolvedScopeRecord {
+                env: None,
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        }];
+        let subscriptions = vec![ResolvedSubscriptionRecord {
+            subscription_id: "sub-a".to_string(),
+            topic: "topic://example.domain.event.v1".to_string(),
+            event_type: "example.domain.event.v1".to_string(),
+            pack_id: "pack-b".to_string(),
+            domain: "events".to_string(),
+            pack_path: pack_path.display().to_string(),
+            capability_id: "cap://subscriber.handle.v1".to_string(),
+            op: "handle".to_string(),
+            payload_schema_ref: None,
+            filter_json_pointer: None,
+            filter_equals: None,
+            delivery_mode: "at_least_once".to_string(),
+            max_attempts: 2,
+            priority: 10,
+            scope: crate::capability_runtime::ResolvedScopeRecord {
+                env: None,
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        }];
+
+        let report = publish_event(
+            tmp.path(),
+            &failing_runner,
+            &ctx,
+            &topics,
+            &subscriptions,
+            PublishEventRequest {
+                topic: "topic://example.domain.event.v1".to_string(),
+                event_type: None,
+                payload: serde_json::json!({"kind":"match"}),
+                correlation_id: None,
+                source: Some("test".to_string()),
+            },
+        )?;
+        assert_eq!(report.failed_deliveries, 1);
+        let dlq = read_dead_letters(tmp.path(), "tenant-a", Some("team-b"))?;
+        assert_eq!(dlq.len(), 1);
+
+        let runner = FakeRunner::default();
+        let replay = replay_event(
+            tmp.path(),
+            &runner,
+            &ctx,
+            &topics,
+            &subscriptions,
+            None,
+            Some(&dlq[0].delivery_id),
+        )?;
+        assert_eq!(replay.successful_deliveries, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_payload_fails_schema_validation() -> Result<()> {
+        let tmp = tempdir()?;
+        let pack_path = write_schema_pack(tmp.path(), "schemas/event.schema.json")?;
+        let runner = FakeRunner::default();
+        let ctx = OperatorContext {
+            tenant: "tenant-a".to_string(),
+            team: Some("team-b".to_string()),
+            correlation_id: None,
+        };
+        let topics = vec![ResolvedTopicRecord {
+            topic: "topic://example.domain.event.v1".to_string(),
+            event_type: "example.domain.event.v1".to_string(),
+            pack_id: "pack-a".to_string(),
+            domain: "events".to_string(),
+            pack_path: pack_path.display().to_string(),
+            publisher_component_ref: "publisher".to_string(),
+            publisher_op: "publish".to_string(),
+            payload_schema_ref: Some("schemas/event.schema.json".to_string()),
+            adapter_kind: crate::capability_runtime::CapabilityAdapterKind::DirectComponent,
+            priority: 10,
+            scope: crate::capability_runtime::ResolvedScopeRecord {
+                env: None,
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        }];
+
+        let err = publish_event(
+            tmp.path(),
+            &runner,
+            &ctx,
+            &topics,
+            &[],
+            PublishEventRequest {
+                topic: "topic://example.domain.event.v1".to_string(),
+                event_type: None,
+                payload: serde_json::json!({"kind": 1}),
+                correlation_id: None,
+                source: None,
+            },
+        )
+        .expect_err("invalid payload");
+        assert!(err.to_string().contains("invalid event payload"));
+        Ok(())
+    }
+
+    fn write_schema_pack(root: &Path, schema_ref: &str) -> Result<std::path::PathBuf> {
+        let pack_path = root.join("schema-pack.gtpack");
+        let file = fs::File::create(&pack_path)?;
+        let mut zip = ZipWriter::new(file);
+        zip.start_file(schema_ref, FileOptions::<()>::default())?;
+        zip.write_all(
+            br#"{"type":"object","properties":{"kind":{"type":"string"}},"required":["kind"]}"#,
+        )?;
+        zip.finish()?;
+        Ok(pack_path)
+    }
+}

--- a/src/capability_runtime.rs
+++ b/src/capability_runtime.rs
@@ -1,0 +1,328 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::capabilities::{
+    CapabilityOfferRecord, CapabilitySubscriptionRecord, CapabilityTopicRecord, ResolveScope,
+};
+use crate::demo::runner_host::OperatorContext;
+use crate::domains::Domain;
+use crate::state_layout;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityAdapterKind {
+    DirectComponent,
+    HttpCompatibility,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedCallableRecord {
+    pub capability_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation_id: Option<String>,
+    pub stable_id: String,
+    pub pack_id: String,
+    pub domain: String,
+    pub pack_path: String,
+    pub provider_component_ref: String,
+    pub provider_op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_schema_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_schema_ref: Option<String>,
+    pub version: String,
+    pub requires_setup: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_qa_ref: Option<String>,
+    pub adapter_kind: CapabilityAdapterKind,
+    pub scope: ResolvedScopeRecord,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedScopeRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedTopicRecord {
+    pub topic: String,
+    pub event_type: String,
+    pub pack_id: String,
+    pub domain: String,
+    pub pack_path: String,
+    pub publisher_component_ref: String,
+    pub publisher_op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_schema_ref: Option<String>,
+    pub adapter_kind: CapabilityAdapterKind,
+    pub priority: i32,
+    pub scope: ResolvedScopeRecord,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolvedSubscriptionRecord {
+    pub subscription_id: String,
+    pub topic: String,
+    pub event_type: String,
+    pub pack_id: String,
+    pub domain: String,
+    pub pack_path: String,
+    pub capability_id: String,
+    pub op: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_schema_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_json_pointer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_equals: Option<String>,
+    pub delivery_mode: String,
+    pub max_attempts: u32,
+    pub priority: i32,
+    pub scope: ResolvedScopeRecord,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityCatalogArtifacts {
+    pub callables: Vec<ResolvedCallableRecord>,
+    pub subscriptions: Vec<ResolvedSubscriptionRecord>,
+    pub topics: Vec<ResolvedTopicRecord>,
+}
+
+impl CapabilityCatalogArtifacts {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+pub fn build_catalog_artifacts(
+    offers: &[CapabilityOfferRecord],
+    topics: &[CapabilityTopicRecord],
+    subscriptions: &[CapabilitySubscriptionRecord],
+    ctx: &OperatorContext,
+    scope: &ResolveScope,
+) -> CapabilityCatalogArtifacts {
+    let callables = offers
+        .iter()
+        .map(|offer| ResolvedCallableRecord {
+            capability_id: offer.cap_id.clone(),
+            operation_id: offer.operation_id.clone(),
+            stable_id: offer.stable_id.clone(),
+            pack_id: offer.pack_id.clone(),
+            domain: domain_name(offer.domain).to_string(),
+            pack_path: offer.pack_path.display().to_string(),
+            provider_component_ref: offer.provider_component_ref.clone(),
+            provider_op: offer.provider_op.clone(),
+            input_schema_ref: offer.input_schema_ref.clone(),
+            output_schema_ref: offer.output_schema_ref.clone(),
+            version: offer.version.clone(),
+            requires_setup: offer.requires_setup,
+            setup_qa_ref: offer.setup_qa_ref.clone(),
+            adapter_kind: adapter_kind(offer.adapter_kind.as_deref()),
+            scope: ResolvedScopeRecord {
+                env: scope.env.clone(),
+                tenant: Some(ctx.tenant.clone()),
+                team: ctx.team.clone(),
+            },
+        })
+        .collect();
+    let topics = topics
+        .iter()
+        .map(|topic| ResolvedTopicRecord {
+            topic: topic.topic.clone(),
+            event_type: topic.event_type.clone(),
+            pack_id: topic.pack_id.clone(),
+            domain: domain_name(topic.domain).to_string(),
+            pack_path: topic.pack_path.display().to_string(),
+            publisher_component_ref: topic.publisher_component_ref.clone(),
+            publisher_op: topic.publisher_op.clone(),
+            payload_schema_ref: topic.payload_schema_ref.clone(),
+            adapter_kind: adapter_kind(topic.adapter_kind.as_deref()),
+            priority: topic.priority,
+            scope: ResolvedScopeRecord {
+                env: scope.env.clone(),
+                tenant: Some(ctx.tenant.clone()),
+                team: ctx.team.clone(),
+            },
+        })
+        .collect();
+    let subscriptions = subscriptions
+        .iter()
+        .map(|subscription| ResolvedSubscriptionRecord {
+            subscription_id: subscription.subscription_id.clone(),
+            topic: subscription.topic.clone(),
+            event_type: subscription.event_type.clone(),
+            pack_id: subscription.pack_id.clone(),
+            domain: domain_name(subscription.domain).to_string(),
+            pack_path: subscription.pack_path.display().to_string(),
+            capability_id: subscription.capability_id.clone(),
+            op: subscription.op.clone(),
+            payload_schema_ref: subscription.payload_schema_ref.clone(),
+            filter_json_pointer: subscription.filter_json_pointer.clone(),
+            filter_equals: subscription.filter_equals.clone(),
+            delivery_mode: subscription.delivery_mode.clone(),
+            max_attempts: subscription.max_attempts,
+            priority: subscription.priority,
+            scope: ResolvedScopeRecord {
+                env: scope.env.clone(),
+                tenant: Some(ctx.tenant.clone()),
+                team: ctx.team.clone(),
+            },
+        })
+        .collect();
+
+    CapabilityCatalogArtifacts {
+        callables,
+        subscriptions,
+        topics,
+    }
+}
+
+pub fn write_capability_catalog_artifacts(
+    root: &Path,
+    tenant: &str,
+    team: Option<&str>,
+    artifacts: &CapabilityCatalogArtifacts,
+) -> anyhow::Result<CapabilityCatalogPaths> {
+    let callables_path = state_layout::capability_state_path(root, tenant, team, "callables.json");
+    let subscriptions_path =
+        state_layout::capability_state_path(root, tenant, team, "subscriptions.json");
+    let topics_path = state_layout::capability_state_path(root, tenant, team, "topics.json");
+
+    write_json(&callables_path, &artifacts.callables)?;
+    write_json(&subscriptions_path, &artifacts.subscriptions)?;
+    write_json(&topics_path, &artifacts.topics)?;
+
+    Ok(CapabilityCatalogPaths {
+        callables: callables_path,
+        subscriptions: subscriptions_path,
+        topics: topics_path,
+    })
+}
+
+fn write_json(path: &PathBuf, value: &impl Serialize) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)?;
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn domain_name(domain: Domain) -> &'static str {
+    match domain {
+        Domain::Messaging => "messaging",
+        Domain::Events => "events",
+        Domain::Secrets => "secrets",
+        Domain::OAuth => "oauth",
+    }
+}
+
+fn adapter_kind(raw: Option<&str>) -> CapabilityAdapterKind {
+    match raw {
+        Some("http_compatibility") => CapabilityAdapterKind::HttpCompatibility,
+        _ => CapabilityAdapterKind::DirectComponent,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::tempdir;
+
+    #[test]
+    fn writes_catalog_files_in_generic_state_layout() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let callable = ResolvedCallableRecord {
+            stable_id: "offer.1".to_string(),
+            pack_id: "pack-a".to_string(),
+            domain: "messaging".to_string(),
+            pack_path: "/tmp/pack-a.gtpack".to_string(),
+            capability_id: "cap://example.v1".to_string(),
+            operation_id: Some("perform_action".to_string()),
+            version: "1".to_string(),
+            provider_component_ref: "provider.component".to_string(),
+            provider_op: "provider.invoke".to_string(),
+            input_schema_ref: Some("schemas/input.json".to_string()),
+            output_schema_ref: Some("schemas/output.json".to_string()),
+            requires_setup: false,
+            setup_qa_ref: None,
+            adapter_kind: CapabilityAdapterKind::DirectComponent,
+            scope: ResolvedScopeRecord {
+                env: Some("dev".to_string()),
+                tenant: Some("tenant-a".to_string()),
+                team: Some("team-b".to_string()),
+            },
+        };
+        let artifacts = CapabilityCatalogArtifacts {
+            callables: vec![callable],
+            subscriptions: vec![ResolvedSubscriptionRecord {
+                subscription_id: "sub-a".to_string(),
+                topic: "topic://example.v1".to_string(),
+                event_type: "example.v1".to_string(),
+                pack_id: "pack-b".to_string(),
+                domain: "events".to_string(),
+                pack_path: "/tmp/pack-b.gtpack".to_string(),
+                capability_id: "cap://subscriber.v1".to_string(),
+                op: "handle".to_string(),
+                payload_schema_ref: Some("schemas/event.json".to_string()),
+                filter_json_pointer: Some("/kind".to_string()),
+                filter_equals: Some("match".to_string()),
+                delivery_mode: "at_least_once".to_string(),
+                max_attempts: 2,
+                priority: 10,
+                scope: ResolvedScopeRecord {
+                    env: Some("dev".to_string()),
+                    tenant: Some("tenant-a".to_string()),
+                    team: Some("team-b".to_string()),
+                },
+            }],
+            topics: vec![ResolvedTopicRecord {
+                topic: "topic://example.v1".to_string(),
+                event_type: "example.v1".to_string(),
+                pack_id: "pack-c".to_string(),
+                domain: "events".to_string(),
+                pack_path: "/tmp/pack-c.gtpack".to_string(),
+                publisher_component_ref: "events.component".to_string(),
+                publisher_op: "publish".to_string(),
+                payload_schema_ref: Some("schemas/event.json".to_string()),
+                adapter_kind: CapabilityAdapterKind::DirectComponent,
+                priority: 5,
+                scope: ResolvedScopeRecord {
+                    env: Some("dev".to_string()),
+                    tenant: Some("tenant-a".to_string()),
+                    team: Some("team-b".to_string()),
+                },
+            }],
+        };
+        let paths =
+            write_capability_catalog_artifacts(tmp.path(), "tenant-a", Some("team-b"), &artifacts)?;
+
+        assert!(paths.callables.exists());
+        assert!(paths.subscriptions.exists());
+        assert!(paths.topics.exists());
+
+        let callables = std::fs::read_to_string(paths.callables)?;
+        let subscriptions = std::fs::read_to_string(paths.subscriptions)?;
+        let topics = std::fs::read_to_string(paths.topics)?;
+        assert!(callables.contains("\"capability_id\": \"cap://example.v1\""));
+        assert!(callables.contains("\"adapter_kind\": \"direct_component\""));
+        assert!(subscriptions.contains("\"subscription_id\": \"sub-a\""));
+        assert!(topics.contains("\"topic\": \"topic://example.v1\""));
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CapabilityCatalogPaths {
+    pub callables: PathBuf,
+    pub subscriptions: PathBuf,
+    pub topics: PathBuf,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,8 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 
 use crate::bin_resolver::{self, ResolveCtx};
 use crate::capabilities::ResolveScope;
+use crate::capability_events;
+use crate::capability_runtime;
 use crate::config;
 use crate::config_gate::{self, ConfigGateItem, ConfigValueSource};
 use crate::demo::{
@@ -119,9 +121,9 @@ enum DemoSubcommand {
     Allow(DemoPolicyArgs),
     #[command(about = "Forbid a tenant/team access to a pack/flow/node")]
     Forbid(DemoPolicyArgs),
-    #[command(about = "Manage demo subscriptions via provider components")]
+    #[command(about = "Manage subscriptions via provider components")]
     Subscriptions(DemoSubscriptionsCommand),
-    #[command(about = "Manage capability resolution/invocation in demo bundles")]
+    #[command(about = "Manage capability resolution and invocation in the local runtime")]
     Capability(DemoCapabilityCommand),
     #[command(about = "Run a pack/flow with inline input")]
     Run(DemoRunArgs),
@@ -849,8 +851,8 @@ struct DemoSendArgs {
 
 #[derive(Parser)]
 #[command(
-    about = "Manage demo subscriptions via provider components.",
-    long_about = "Ensure, renew, or delete provider-managed subscriptions from a demo bundle."
+    about = "Manage subscriptions via provider components.",
+    long_about = "Ensure, renew, or delete provider-managed subscriptions in the local runtime."
 )]
 struct DemoSubscriptionsCommand {
     #[command(subcommand)]
@@ -859,8 +861,8 @@ struct DemoSubscriptionsCommand {
 
 #[derive(Parser)]
 #[command(
-    about = "Manage capabilities in a demo bundle.",
-    long_about = "Resolve, invoke, and mark setup status for capability offers."
+    about = "Manage capabilities in the local runtime.",
+    long_about = "Resolve, invoke, and export capability bindings for the local runtime."
 )]
 struct DemoCapabilityCommand {
     #[command(subcommand)]
@@ -869,10 +871,30 @@ struct DemoCapabilityCommand {
 
 #[derive(Subcommand)]
 enum DemoCapabilitySubcommand {
+    List(DemoCapabilityListArgs),
+    Call(DemoCapabilityCallArgs),
     Invoke(DemoCapabilityInvokeArgs),
+    Events(DemoCapabilityEventsCommand),
+    Subscriptions(DemoCapabilitySubscriptionsCommand),
     SetupPlan(DemoCapabilitySetupPlanArgs),
     MarkReady(DemoCapabilityMarkReadyArgs),
     MarkFailed(DemoCapabilityMarkFailedArgs),
+}
+
+#[derive(Parser)]
+#[command(
+    about = "List resolved capability bindings.",
+    long_about = "Resolves all capabilities visible in the current tenant/team scope and writes the generic capability catalog artifacts."
+)]
+struct DemoCapabilityListArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+    #[arg(long)]
+    env: Option<String>,
 }
 
 #[derive(Parser)]
@@ -889,6 +911,127 @@ struct DemoCapabilityInvokeArgs {
     op: String,
     #[arg(long)]
     payload_json: Option<String>,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+    #[arg(long)]
+    env: Option<String>,
+}
+
+#[derive(Parser)]
+#[command(
+    about = "Resolve and call a capability with optional schema validation.",
+    long_about = "Loads the resolved callable binding from the capability catalog, validates input/output schemas when declared, and invokes the selected provider op through the local runner host."
+)]
+struct DemoCapabilityCallArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long)]
+    cap_id: String,
+    #[arg(long)]
+    operation: String,
+    #[arg(long)]
+    input_json: Option<String>,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+    #[arg(long)]
+    env: Option<String>,
+}
+
+#[derive(Parser)]
+#[command(
+    about = "Manage local capability event delivery.",
+    long_about = "Publishes events into the local capability event bus and inspects/replays the audit and DLQ logs."
+)]
+struct DemoCapabilityEventsCommand {
+    #[command(subcommand)]
+    command: DemoCapabilityEventsSubcommand,
+}
+
+#[derive(Subcommand)]
+enum DemoCapabilityEventsSubcommand {
+    Publish(DemoCapabilityEventsPublishArgs),
+    Tail(DemoCapabilityEventsTailArgs),
+    Dlq(DemoCapabilityEventsDlqArgs),
+    Replay(DemoCapabilityEventsReplayArgs),
+}
+
+#[derive(Parser)]
+struct DemoCapabilityEventsPublishArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long)]
+    topic: String,
+    #[arg(long)]
+    event_type: Option<String>,
+    #[arg(long)]
+    input_json: String,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+    #[arg(long)]
+    env: Option<String>,
+}
+
+#[derive(Parser)]
+struct DemoCapabilityEventsTailArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+}
+
+#[derive(Parser)]
+struct DemoCapabilityEventsDlqArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+}
+
+#[derive(Parser)]
+struct DemoCapabilityEventsReplayArgs {
+    #[arg(long)]
+    bundle: PathBuf,
+    #[arg(long)]
+    event_id: Option<String>,
+    #[arg(long)]
+    delivery_id: Option<String>,
+    #[arg(long, default_value = "demo")]
+    tenant: String,
+    #[arg(long, default_value = "default")]
+    team: String,
+    #[arg(long)]
+    env: Option<String>,
+}
+
+#[derive(Parser)]
+#[command(
+    about = "List resolved event subscriptions.",
+    long_about = "Prints the resolved generic capability event subscriptions visible in the current tenant/team scope."
+)]
+struct DemoCapabilitySubscriptionsCommand {
+    #[command(subcommand)]
+    command: DemoCapabilitySubscriptionsSubcommand,
+}
+
+#[derive(Subcommand)]
+enum DemoCapabilitySubscriptionsSubcommand {
+    List(DemoCapabilitySubscriptionsListArgs),
+}
+
+#[derive(Parser)]
+struct DemoCapabilitySubscriptionsListArgs {
+    #[arg(long)]
+    bundle: PathBuf,
     #[arg(long, default_value = "demo")]
     tenant: String,
     #[arg(long, default_value = "default")]
@@ -1098,10 +1241,33 @@ impl DemoSubscriptionsCommand {
     }
 }
 
+impl DemoCapabilityEventsCommand {
+    fn run(self) -> anyhow::Result<()> {
+        match self.command {
+            DemoCapabilityEventsSubcommand::Publish(args) => args.run(),
+            DemoCapabilityEventsSubcommand::Tail(args) => args.run(),
+            DemoCapabilityEventsSubcommand::Dlq(args) => args.run(),
+            DemoCapabilityEventsSubcommand::Replay(args) => args.run(),
+        }
+    }
+}
+
+impl DemoCapabilitySubscriptionsCommand {
+    fn run(self) -> anyhow::Result<()> {
+        match self.command {
+            DemoCapabilitySubscriptionsSubcommand::List(args) => args.run(),
+        }
+    }
+}
+
 impl DemoCapabilityCommand {
     fn run(self) -> anyhow::Result<()> {
         match self.command {
+            DemoCapabilitySubcommand::List(args) => args.run(),
+            DemoCapabilitySubcommand::Call(args) => args.run(),
             DemoCapabilitySubcommand::Invoke(args) => args.run(),
+            DemoCapabilitySubcommand::Events(args) => args.run(),
+            DemoCapabilitySubcommand::Subscriptions(args) => args.run(),
             DemoCapabilitySubcommand::SetupPlan(args) => args.run(),
             DemoCapabilitySubcommand::MarkReady(args) => args.run(),
             DemoCapabilitySubcommand::MarkFailed(args) => args.run(),
@@ -1635,6 +1801,341 @@ impl DemoCapabilityInvokeArgs {
     }
 }
 
+impl DemoCapabilityCallArgs {
+    fn run(self) -> anyhow::Result<()> {
+        if let Some(env_value) = self.env.as_ref() {
+            unsafe {
+                env::set_var("GREENTIC_ENV", env_value);
+            }
+        }
+        domains::ensure_cbor_packs(&self.bundle)?;
+        let discovery = discovery::discover_with_options(
+            &self.bundle,
+            discovery::DiscoveryOptions { cbor_only: true },
+        )?;
+        let secrets_handle =
+            secrets_gate::resolve_secrets_manager(&self.bundle, &self.tenant, Some(&self.team))?;
+        let runner_host =
+            DemoRunnerHost::new(self.bundle.clone(), &discovery, None, secrets_handle, false)?;
+        let ctx = OperatorContext {
+            tenant: self.tenant.clone(),
+            team: Some(self.team.clone()),
+            correlation_id: None,
+        };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(self.tenant.clone()),
+            team: Some(self.team.clone()),
+        };
+        let offers = runner_host.capability_offers_in_scope(&scope);
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts = capability_runtime::build_catalog_artifacts(
+            &offers,
+            &topics,
+            &subscriptions,
+            &ctx,
+            &scope,
+        );
+        let callable = artifacts
+            .callables
+            .iter()
+            .find(|item| {
+                item.capability_id == self.cap_id
+                    && item.operation_id.as_deref() == Some(self.operation.as_str())
+            })
+            .or_else(|| {
+                artifacts.callables.iter().find(|item| {
+                    item.capability_id == self.cap_id && item.provider_op == self.operation
+                })
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "capability {} operation {} is not resolved in current scope",
+                    self.cap_id,
+                    self.operation
+                )
+            })?;
+        let input_value = if let Some(raw) = self.input_json.as_ref() {
+            serde_json::from_str::<JsonValue>(raw)
+                .map_err(|err| anyhow!("invalid --input-json: {err}"))?
+        } else {
+            json!({})
+        };
+        if let Some(schema_ref) = callable.input_schema_ref.as_deref() {
+            validate_pack_schema(&callable.pack_path, schema_ref, &input_value).with_context(
+                || format!("invalid input for capability {}", callable.capability_id),
+            )?;
+        }
+        let payload_bytes = serde_json::to_vec(&input_value)?;
+        let requested_op = callable
+            .operation_id
+            .as_deref()
+            .unwrap_or(self.operation.as_str());
+        let outcome = runner_host.invoke_capability(
+            &callable.capability_id,
+            requested_op,
+            &payload_bytes,
+            &ctx,
+        )?;
+        if let Some(schema_ref) = callable.output_schema_ref.as_deref() {
+            let output = outcome.output.clone().unwrap_or(JsonValue::Null);
+            validate_pack_schema(&callable.pack_path, schema_ref, &output).with_context(|| {
+                format!("invalid output for capability {}", callable.capability_id)
+            })?;
+        }
+        print_capability_outcome(&outcome)?;
+        if !outcome.success {
+            anyhow::bail!(
+                "capability call failed cap_id={} operation={}",
+                callable.capability_id,
+                self.operation
+            );
+        }
+        Ok(())
+    }
+}
+
+impl DemoCapabilityListArgs {
+    fn run(self) -> anyhow::Result<()> {
+        if let Some(env_value) = self.env.as_ref() {
+            unsafe {
+                env::set_var("GREENTIC_ENV", env_value);
+            }
+        }
+        domains::ensure_cbor_packs(&self.bundle)?;
+        let discovery = discovery::discover_with_options(
+            &self.bundle,
+            discovery::DiscoveryOptions { cbor_only: true },
+        )?;
+        let secrets_handle =
+            secrets_gate::resolve_secrets_manager(&self.bundle, &self.tenant, Some(&self.team))?;
+        let runner_host =
+            DemoRunnerHost::new(self.bundle.clone(), &discovery, None, secrets_handle, false)?;
+        let ctx = OperatorContext {
+            tenant: self.tenant.clone(),
+            team: Some(self.team.clone()),
+            correlation_id: None,
+        };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(self.tenant.clone()),
+            team: Some(self.team.clone()),
+        };
+        let offers = runner_host.capability_offers_in_scope(&scope);
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts = capability_runtime::build_catalog_artifacts(
+            &offers,
+            &topics,
+            &subscriptions,
+            &ctx,
+            &scope,
+        );
+        let paths = capability_runtime::write_capability_catalog_artifacts(
+            &self.bundle,
+            &self.tenant,
+            Some(&self.team),
+            &artifacts,
+        )?;
+
+        println!(
+            "wrote {} callable capability binding(s) to {}",
+            artifacts.callables.len(),
+            paths.callables.display()
+        );
+        println!("subscriptions catalog: {}", paths.subscriptions.display());
+        println!("topics catalog: {}", paths.topics.display());
+        for item in artifacts.callables {
+            println!(
+                "{} | cap={} | pack={} | op={} | adapter={:?}",
+                item.stable_id,
+                item.capability_id,
+                item.pack_id,
+                item.provider_op,
+                item.adapter_kind
+            );
+        }
+        Ok(())
+    }
+}
+
+impl DemoCapabilitySubscriptionsListArgs {
+    fn run(self) -> anyhow::Result<()> {
+        if let Some(env_value) = self.env.as_ref() {
+            unsafe {
+                env::set_var("GREENTIC_ENV", env_value);
+            }
+        }
+        domains::ensure_cbor_packs(&self.bundle)?;
+        let discovery = discovery::discover_with_options(
+            &self.bundle,
+            discovery::DiscoveryOptions { cbor_only: true },
+        )?;
+        let secrets_handle =
+            secrets_gate::resolve_secrets_manager(&self.bundle, &self.tenant, Some(&self.team))?;
+        let runner_host =
+            DemoRunnerHost::new(self.bundle.clone(), &discovery, None, secrets_handle, false)?;
+        let ctx = OperatorContext {
+            tenant: self.tenant.clone(),
+            team: Some(self.team.clone()),
+            correlation_id: None,
+        };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(self.tenant.clone()),
+            team: Some(self.team.clone()),
+        };
+        let offers = runner_host.capability_offers_in_scope(&scope);
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts = capability_runtime::build_catalog_artifacts(
+            &offers,
+            &topics,
+            &subscriptions,
+            &ctx,
+            &scope,
+        );
+        for item in artifacts.subscriptions {
+            println!(
+                "{} | topic={} | event_type={} | capability={} | op={} | attempts={}",
+                item.subscription_id,
+                item.topic,
+                item.event_type,
+                item.capability_id,
+                item.op,
+                item.max_attempts
+            );
+        }
+        Ok(())
+    }
+}
+
+impl DemoCapabilityEventsPublishArgs {
+    fn run(self) -> anyhow::Result<()> {
+        if let Some(env_value) = self.env.as_ref() {
+            unsafe {
+                env::set_var("GREENTIC_ENV", env_value);
+            }
+        }
+        let payload = serde_json::from_str::<JsonValue>(&self.input_json)
+            .map_err(|err| anyhow!("invalid --input-json: {err}"))?;
+        domains::ensure_cbor_packs(&self.bundle)?;
+        let discovery = discovery::discover_with_options(
+            &self.bundle,
+            discovery::DiscoveryOptions { cbor_only: true },
+        )?;
+        let secrets_handle =
+            secrets_gate::resolve_secrets_manager(&self.bundle, &self.tenant, Some(&self.team))?;
+        let runner_host =
+            DemoRunnerHost::new(self.bundle.clone(), &discovery, None, secrets_handle, false)?;
+        let ctx = OperatorContext {
+            tenant: self.tenant.clone(),
+            team: Some(self.team.clone()),
+            correlation_id: None,
+        };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(self.tenant.clone()),
+            team: Some(self.team.clone()),
+        };
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts =
+            capability_runtime::build_catalog_artifacts(&[], &topics, &subscriptions, &ctx, &scope);
+        let report = capability_events::publish_event(
+            &self.bundle,
+            &runner_host,
+            &ctx,
+            &artifacts.topics,
+            &artifacts.subscriptions,
+            capability_events::PublishEventRequest {
+                topic: self.topic,
+                event_type: self.event_type,
+                payload,
+                correlation_id: None,
+                source: Some("demo capability events publish".to_string()),
+            },
+        )?;
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "matched_subscriptions": report.matched_subscriptions,
+                "successful_deliveries": report.successful_deliveries,
+                "failed_deliveries": report.failed_deliveries,
+            }))?
+        );
+        Ok(())
+    }
+}
+
+impl DemoCapabilityEventsTailArgs {
+    fn run(self) -> anyhow::Result<()> {
+        let events = capability_events::read_events(&self.bundle, &self.tenant, Some(&self.team))?;
+        for item in events {
+            println!("{}", serde_json::to_string(&item)?);
+        }
+        Ok(())
+    }
+}
+
+impl DemoCapabilityEventsDlqArgs {
+    fn run(self) -> anyhow::Result<()> {
+        let items =
+            capability_events::read_dead_letters(&self.bundle, &self.tenant, Some(&self.team))?;
+        for item in items {
+            println!("{}", serde_json::to_string(&item)?);
+        }
+        Ok(())
+    }
+}
+
+impl DemoCapabilityEventsReplayArgs {
+    fn run(self) -> anyhow::Result<()> {
+        if let Some(env_value) = self.env.as_ref() {
+            unsafe {
+                env::set_var("GREENTIC_ENV", env_value);
+            }
+        }
+        domains::ensure_cbor_packs(&self.bundle)?;
+        let discovery = discovery::discover_with_options(
+            &self.bundle,
+            discovery::DiscoveryOptions { cbor_only: true },
+        )?;
+        let secrets_handle =
+            secrets_gate::resolve_secrets_manager(&self.bundle, &self.tenant, Some(&self.team))?;
+        let runner_host =
+            DemoRunnerHost::new(self.bundle.clone(), &discovery, None, secrets_handle, false)?;
+        let ctx = OperatorContext {
+            tenant: self.tenant.clone(),
+            team: Some(self.team.clone()),
+            correlation_id: None,
+        };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(self.tenant.clone()),
+            team: Some(self.team.clone()),
+        };
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts =
+            capability_runtime::build_catalog_artifacts(&[], &topics, &subscriptions, &ctx, &scope);
+        let report = capability_events::replay_event(
+            &self.bundle,
+            &runner_host,
+            &ctx,
+            &artifacts.topics,
+            &artifacts.subscriptions,
+            self.event_id.as_deref(),
+            self.delivery_id.as_deref(),
+        )?;
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "matched_subscriptions": report.matched_subscriptions,
+                "successful_deliveries": report.successful_deliveries,
+                "failed_deliveries": report.failed_deliveries,
+            }))?
+        );
+        Ok(())
+    }
+}
+
 impl DemoCapabilitySetupPlanArgs {
     fn run(self) -> anyhow::Result<()> {
         domains::ensure_cbor_packs(&self.bundle)?;
@@ -1651,6 +2152,26 @@ impl DemoCapabilitySetupPlanArgs {
             team: Some(self.team),
             correlation_id: None,
         };
+        let scope = ResolveScope {
+            env: env::var("GREENTIC_ENV").ok(),
+            tenant: Some(ctx.tenant.clone()),
+            team: ctx.team.clone(),
+        };
+        let offers = runner_host.capability_offers_in_scope(&scope);
+        let (topics, subscriptions) = runner_host.capability_event_bindings_in_scope(&scope)?;
+        let artifacts = capability_runtime::build_catalog_artifacts(
+            &offers,
+            &topics,
+            &subscriptions,
+            &ctx,
+            &scope,
+        );
+        let _paths = capability_runtime::write_capability_catalog_artifacts(
+            &self.bundle,
+            &ctx.tenant,
+            ctx.team.as_deref(),
+            &artifacts,
+        )?;
         let plan = runner_host.capability_setup_plan(&ctx);
         if plan.is_empty() {
             println!(
@@ -4546,6 +5067,37 @@ fn print_capability_outcome(outcome: &FlowOutcome) -> anyhow::Result<()> {
         println!("{}", serde_json::to_string_pretty(value)?);
     }
     Ok(())
+}
+
+fn validate_pack_schema(
+    pack_path: &str,
+    schema_ref: &str,
+    value: &JsonValue,
+) -> anyhow::Result<()> {
+    let schema = load_pack_schema(pack_path, schema_ref)?;
+    jsonschema::validate(&schema, value).map_err(|err| anyhow!("{err}"))
+}
+
+fn load_pack_schema(pack_path: &str, schema_ref: &str) -> anyhow::Result<JsonValue> {
+    let path = Path::new(pack_path);
+    if path.is_dir() {
+        let schema_path = path.join(schema_ref);
+        let bytes = fs::read(&schema_path)
+            .with_context(|| format!("failed to read schema {}", schema_path.display()))?;
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse schema {}", schema_path.display()));
+    }
+
+    let file = fs::File::open(path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    let mut entry = archive
+        .by_name(schema_ref)
+        .with_context(|| format!("schema {schema_ref} missing in {}", path.display()))?;
+    let mut bytes = Vec::new();
+    use std::io::Read as _;
+    entry.read_to_end(&mut bytes)?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to parse schema {schema_ref} in {}", path.display()))
 }
 
 #[derive(Parser)]

--- a/src/demo/runner_host.rs
+++ b/src/demo/runner_host.rs
@@ -61,9 +61,10 @@ use crate::runner_integration::run_flow_with_options;
 
 use crate::capabilities::{
     CAP_OAUTH_BROKER_V1, CAP_OAUTH_TOKEN_VALIDATION_V1, CapabilityBinding, CapabilityInstallRecord,
-    CapabilityPackRecord, CapabilityRegistry, HookStage, OAUTH_OP_AWAIT_RESULT,
-    OAUTH_OP_GET_ACCESS_TOKEN, OAUTH_OP_INITIATE_AUTH, OAUTH_OP_REQUEST_RESOURCE_TOKEN,
-    ResolveScope, is_binding_ready, is_oauth_broker_operation, write_install_record,
+    CapabilityPackRecord, CapabilityRegistry, CapabilitySubscriptionRecord, CapabilityTopicRecord,
+    HookStage, OAUTH_OP_AWAIT_RESULT, OAUTH_OP_GET_ACCESS_TOKEN, OAUTH_OP_INITIATE_AUTH,
+    OAUTH_OP_REQUEST_RESOURCE_TOKEN, ResolveScope, collect_event_bindings_for_packs,
+    is_binding_ready, is_oauth_broker_operation, write_install_record,
 };
 use crate::cards::CardRenderer;
 use crate::discovery;
@@ -306,6 +307,47 @@ impl DemoRunnerHost {
 
     pub fn resolve_hook_chain(&self, stage: HookStage, op_name: &str) -> Vec<CapabilityBinding> {
         self.capability_registry.resolve_hook_chain(stage, op_name)
+    }
+
+    pub fn capability_offers_in_scope(
+        &self,
+        scope: &ResolveScope,
+    ) -> Vec<crate::capabilities::CapabilityOfferRecord> {
+        self.capability_registry.offers_in_scope(scope)
+    }
+
+    pub fn capability_event_bindings_in_scope(
+        &self,
+        scope: &ResolveScope,
+    ) -> anyhow::Result<(
+        Vec<CapabilityTopicRecord>,
+        Vec<CapabilitySubscriptionRecord>,
+    )> {
+        let pack_index = self
+            .packs_by_path
+            .values()
+            .map(|pack| {
+                let domain = self
+                    .catalog
+                    .iter()
+                    .find_map(|((domain, _), provider)| {
+                        if provider.path == pack.path {
+                            Some(*domain)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(Domain::Messaging);
+                (
+                    pack.path.clone(),
+                    CapabilityPackRecord {
+                        pack_id: pack.pack_id.clone(),
+                        domain,
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        collect_event_bindings_for_packs(&pack_index, scope)
     }
 
     pub fn has_provider_packs_for_domain(&self, domain: Domain) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod admin_api;
 pub mod bin_resolver;
 pub mod capabilities;
 pub mod capability_bootstrap;
+pub mod capability_events;
+pub mod capability_runtime;
 pub mod cards;
 pub mod cli;
 pub mod cloudflared;

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,14 +281,14 @@ fn print_demo_help() {
         "  subscriptions  {}",
         operator_i18n::tr(
             "cli.demo.help.command.subscriptions",
-            "Manage demo subscriptions via provider components"
+            "Manage subscriptions via provider components"
         )
     );
     println!(
         "  capability     {}",
         operator_i18n::tr(
             "cli.demo.help.command.capability",
-            "Manage capability resolution/invocation in demo bundles"
+            "Manage capability resolution and invocation in the local runtime"
         )
     );
     println!(

--- a/src/state_layout.rs
+++ b/src/state_layout.rs
@@ -29,6 +29,22 @@ pub fn secrets_log_path(root: &Path, action: &str) -> anyhow::Result<PathBuf> {
         .join(format!("{action}-{timestamp}.log")))
 }
 
+pub fn capability_state_dir(root: &Path, tenant: &str, team: Option<&str>) -> PathBuf {
+    root.join("state")
+        .join("capabilities")
+        .join(tenant)
+        .join(team.unwrap_or("default"))
+}
+
+pub fn capability_state_path(
+    root: &Path,
+    tenant: &str,
+    team: Option<&str>,
+    file_name: &str,
+) -> PathBuf {
+    capability_state_dir(root, tenant, team).join(file_name)
+}
+
 fn domain_name(domain: Domain) -> &'static str {
     match domain {
         Domain::Messaging => "messaging",


### PR DESCRIPTION
## What changed
- add generic capability catalog export for callable, topic, and subscription bindings under `state/capabilities/...`
- extend `greentic.ext.capabilities.v1` parsing with callable metadata plus topic/subscription declarations
- add local JSONL-backed event publish, delivery audit, DLQ, and replay support
- add `demo capability call`, `demo capability subscriptions list`, and `demo capability events ...` command paths
- move the implementation PR note into `.codex/done/PR-OP-capability-runtime-events.md`

## Why
We needed the existing operator capability path to support generic callable bindings and local pub/sub delivery without hard-coding specific runtimes or business domains.

## Impact
This gives bundle-backed local runtimes a deterministic resolved capability catalog plus a reusable local event bus for capability-oriented integration flows.

## Validation
- `cargo fmt --all`
- `cargo test capability_events --lib` was attempted, but the build is currently blocked by an upstream dependency mismatch in `greentic-runner-host` from the Cargo registry:
  - unresolved import `greentic_types::telemetry::attr_keys`
  - missing `provider_id` field on `ProviderDecl`

Those compile errors occur outside this diff, so review should focus on the operator-side implementation in this PR.