### PR TITLE
chore(deps): floor deployer at 1.1.0-dev.26948183687 — pick up `op extensions` noun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.1.26628825486"
+version = "0.1.26948183687"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e7f27d60deb46ff7816c2fc75cad782e0c03628e4e56f2292d55b78d2c9419"
+checksum = "9b7f1a92d45b2f0b2504e4fd31a348f9ef78172c02fd9ec58c70f1d16e92771e"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -2701,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.26628825486"
+version = "1.1.0-dev.26948183687"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b355c02bdac7c280673a102ac9ac6d56b5bba1048dfae244d9835086e257e"
+checksum = "260f7c33b924f56be7bdb790705b032bfc65ee0cd0b5c02d2c7b7a82467ae2c5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5300,7 +5300,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,10 @@ async-trait = "0.1"
 base64 = "0.22"
 chrono = "0.4"
 directories-next = "2"
-greentic-deploy-spec = ">=0.1, <0.2"
-greentic-deployer = ">=1.1.0-dev, <1.2.0-0"
+# Floor 0.1.26948183687: ExtensionBinding / ExtensionRef (Path 3 capability slot).
+greentic-deploy-spec = ">=0.1.26948183687, <0.2"
+# Floor 1.1.0-dev.26948183687: `op extensions` noun (compiled into this CLI via OpCommand).
+greentic-deployer = ">=1.1.0-dev.26948183687, <1.2.0-0"
 greentic-setup = ">=1.1.0-dev, <1.2.0-0"
 greentic-qa-lib = ">=1.1.0-dev, <1.2.0-0"
 greentic-start = ">=1.1.0-dev, <1.2.0-0"

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -182,12 +182,10 @@ fn check_trust_boundary(
                 ),
             )));
         }
-        // A local tunnel daemon (cloudflared/ngrok — `demo up` starts one
-        // by default) connects from a loopback peer, so the check above
-        // cannot see tunneled remote traffic. The daemon always injects
-        // forwarding headers the remote caller cannot strip — refuse on
-        // their presence. Skipped when `loopback_only = false`: a Phase D
-        // upstream admission proxy legitimately adds these headers.
+        // Tunnel daemons collapse the peer-IP check above (module doc,
+        // "No proxy/tunnel forwarding markers"). Skipped when
+        // `loopback_only = false`: a Phase D upstream admission proxy
+        // legitimately adds these headers.
         if let Some(marker) = forwarding_marker(headers) {
             return Err(into_error(error_response(
                 StatusCode::FORBIDDEN,
@@ -480,6 +478,15 @@ mod tests {
         })
     }
 
+    /// `loopback_only = false` variant — the Phase D "caller wired their own
+    /// admission upstream" configuration.
+    fn state_with_tempdir_open(tmp: &tempfile::TempDir) -> Arc<DeploymentsState> {
+        Arc::new(DeploymentsState {
+            env_root: Some(tmp.path().to_path_buf()),
+            loopback_only: false,
+        })
+    }
+
     fn loopback_peer() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234)
     }
@@ -742,10 +749,7 @@ mod tests {
         // legitimately adds forwarding headers — the marker check must not
         // fire once the caller has wired real admission upstream.
         let tmp = tempfile::tempdir().unwrap();
-        let state = Arc::new(DeploymentsState {
-            env_root: Some(tmp.path().to_path_buf()),
-            loopback_only: false,
-        });
+        let state = state_with_tempdir_open(&tmp);
         let mut headers = HeaderMap::new();
         headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.7"));
         check_trust_boundary(remote_peer(), &headers, &state)
@@ -757,10 +761,7 @@ mod tests {
         // Phase D path: caller has wired in their own admission upstream.
         // We still defend in depth against browser CSRF via Origin.
         let tmp = tempfile::tempdir().unwrap();
-        let state = Arc::new(DeploymentsState {
-            env_root: Some(tmp.path().to_path_buf()),
-            loopback_only: false,
-        });
+        let state = state_with_tempdir_open(&tmp);
         let headers = HeaderMap::new();
         check_trust_boundary(remote_peer(), &headers, &state)
             .expect("remote peer must pass when loopback_only=false");

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -14,6 +14,12 @@
 //!
 //! - **Peer must be loopback** when `loopback_only` is set. Set to `false`
 //!   only after mTLS / admin admission lands.
+//! - **No proxy/tunnel forwarding markers** when `loopback_only` is set —
+//!   tunnel daemons (cloudflared, ngrok) run locally and connect from a
+//!   loopback peer, so the peer-IP check alone cannot tell tunneled remote
+//!   traffic from a genuinely local caller. The daemon always injects
+//!   forwarding headers the remote caller cannot strip; their presence
+//!   fails the gate.
 //! - **`Origin` header (if present) must point at loopback** — blocks
 //!   browser cross-origin CSRF even when the bind address is loopback
 //!   (the shared ingress applies wildcard CORS to all responses).
@@ -166,14 +172,32 @@ fn check_trust_boundary(
     headers: &HeaderMap<HeaderValue>,
     state: &Arc<DeploymentsState>,
 ) -> Result<(), DeploymentError> {
-    if state.loopback_only && !peer_addr.ip().is_loopback() {
-        return Err(into_error(error_response(
-            StatusCode::FORBIDDEN,
-            format!(
-                "/deployments/* refused: peer {peer_addr} is not loopback; \
-                 mTLS / admin admission is Phase D (plan §B4b)"
-            ),
-        )));
+    if state.loopback_only {
+        if !peer_addr.ip().is_loopback() {
+            return Err(into_error(error_response(
+                StatusCode::FORBIDDEN,
+                format!(
+                    "/deployments/* refused: peer {peer_addr} is not loopback; \
+                     mTLS / admin admission is Phase D (plan §B4b)"
+                ),
+            )));
+        }
+        // A local tunnel daemon (cloudflared/ngrok — `demo up` starts one
+        // by default) connects from a loopback peer, so the check above
+        // cannot see tunneled remote traffic. The daemon always injects
+        // forwarding headers the remote caller cannot strip — refuse on
+        // their presence. Skipped when `loopback_only = false`: a Phase D
+        // upstream admission proxy legitimately adds these headers.
+        if let Some(marker) = forwarding_marker(headers) {
+            return Err(into_error(error_response(
+                StatusCode::FORBIDDEN,
+                format!(
+                    "/deployments/* refused: request bears forwarding marker \
+                     `{marker}` (proxied/tunneled traffic); direct local \
+                     callers only until mTLS lands (plan §B4b)"
+                ),
+            )));
+        }
     }
     if let Some(origin) = headers.get(ORIGIN).and_then(|v| v.to_str().ok())
         && !is_loopback_origin(origin)
@@ -187,6 +211,28 @@ fn check_trust_boundary(
         )));
     }
     Ok(())
+}
+
+/// Header names (already lowercase in hyper's `HeaderMap`) that mark a
+/// request as having transited a reverse proxy or tunnel daemon. Covers the
+/// `X-Forwarded` family (cloudflared, ngrok, generic proxies), `X-Real-IP`
+/// (nginx), and RFC 7239 `Forwarded`.
+const FORWARDING_MARKER_HEADERS: [&str; 5] = [
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-real-ip",
+    "forwarded",
+];
+
+/// First forwarding marker borne by the request, if any: a known forwarding
+/// header or any `cf-*` header (cloudflared injects several beyond the
+/// `X-Forwarded` family, e.g. `cf-connecting-ip`, `cf-ray`).
+fn forwarding_marker(headers: &HeaderMap<HeaderValue>) -> Option<&str> {
+    headers
+        .keys()
+        .map(|name| name.as_str())
+        .find(|name| FORWARDING_MARKER_HEADERS.contains(name) || name.starts_with("cf-"))
 }
 
 /// True for `http(s)://localhost[:port]`, `http(s)://127.0.0.1[:port]`,
@@ -652,6 +698,58 @@ mod tests {
         let err = check_trust_boundary(loopback_peer(), &headers, &state)
             .expect_err("remote Origin must be refused");
         assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn check_trust_boundary_blocks_tunneled_loopback_traffic() {
+        // The cloudflared scenario: `demo up` tunnels a local port, so
+        // remote traffic arrives with a loopback TCP peer and no Origin
+        // (curl-style). The tunnel daemon injects forwarding headers the
+        // remote caller cannot strip — the gate must refuse on them.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = state_with_tempdir(&tmp);
+        let mut cloudflared = HeaderMap::new();
+        cloudflared.insert("cf-connecting-ip", HeaderValue::from_static("203.0.113.7"));
+        cloudflared.insert("cf-ray", HeaderValue::from_static("8a1b2c3d4e5f6789-AMS"));
+        cloudflared.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.7"));
+        let err = check_trust_boundary(loopback_peer(), &cloudflared, &state)
+            .expect_err("cloudflared-tunneled traffic must be refused");
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+
+        // ngrok injects only the X-Forwarded family — each marker alone
+        // must trip the gate.
+        for (name, value) in [
+            ("x-forwarded-for", "203.0.113.7"),
+            ("x-forwarded-host", "abc123.ngrok-free.app"),
+            ("x-forwarded-proto", "https"),
+            ("x-real-ip", "203.0.113.7"),
+            ("forwarded", "for=203.0.113.7"),
+            ("cf-warp-tag-id", "tag"),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert(name, HeaderValue::from_static(value));
+            let err = match check_trust_boundary(loopback_peer(), &headers, &state) {
+                Err(err) => err,
+                Ok(()) => panic!("marker `{name}` must be refused"),
+            };
+            assert_eq!(err.status(), StatusCode::FORBIDDEN, "marker `{name}`");
+        }
+    }
+
+    #[test]
+    fn loopback_only_false_allows_forwarding_markers() {
+        // Phase D path: an upstream admission proxy (mTLS terminator)
+        // legitimately adds forwarding headers — the marker check must not
+        // fire once the caller has wired real admission upstream.
+        let tmp = tempfile::tempdir().unwrap();
+        let state = Arc::new(DeploymentsState {
+            env_root: Some(tmp.path().to_path_buf()),
+            loopback_only: false,
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.7"));
+        check_trust_boundary(remote_peer(), &headers, &state)
+            .expect("forwarding markers must pass when loopback_only=false");
     }
 
     #[test]

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -748,6 +748,7 @@ mod tests {
             revisions: vec![rev],
             traffic_splits: Vec::new(),
             messaging_endpoints: Vec::new(),
+            extensions: Vec::new(),
             revocation: Default::default(),
             retention: Default::default(),
             health: Default::default(),


### PR DESCRIPTION
## Why

deployer #239/#240 added the `op extensions {add,update,remove,rollback,list}` noun (Path 3 extension capability slot) and dev-published it as `1.1.0-dev.26948183687`. Every `op` noun is compiled **into** greentic-operator via `OpCommand` — the installed operator (0.4.49, lock at `26628825486`) answers `unrecognized subcommand 'extensions'` today.

## What

- **Cargo.toml floors raised** (mirrors greentic-start #224): `greentic-deployer >=1.1.0-dev.26948183687`, `greentic-deploy-spec >=0.1.26948183687` — a fresh lock can't regress below the noun.
- **Cargo.lock** refreshed via targeted `cargo update -p <name>@<old> --precise <new>` (10-line diff, nothing else moved).
- **Test fixture**: the deploy-spec bump surfaced the new `Environment.extensions` field at one `Environment{}` literal (`src/deployments/api.rs`) — added `extensions: Vec::new()`.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo fmt --all --check` clean
- `cargo test`: **255 passed, 0 failed**
- Built binary smoke: `greentic-operator op extensions list local` → `{"noun":"extensions","op":"list","result":{"environment_id":"local","extensions":[]}}`