### PR TITLE
chore(deps): bump deployer/setup/start/runner-host for op deploy route_binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-iam"
+version = "1.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bd7de042cef2c02c335c6e1e8b799024f985852a9804bf9b7811f0e3c43ba3"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,29 +1435,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
-dependencies = [
- "cranelift-assembler-x64-meta 0.130.2",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
 version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c4ebb31662e2051dcc49b7342d222405a99e951720756cc4b93315972abd67"
 dependencies = [
- "cranelift-assembler-x64-meta 0.132.1",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
-dependencies = [
- "cranelift-srcgen 0.130.2",
+ "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
@@ -1440,17 +1448,7 @@ version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dfc2ec96ec1c3a8a250602e936712e00a381df032f7a8ad175c8f768c03bb"
 dependencies = [
- "cranelift-srcgen 0.132.1",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
-dependencies = [
- "cranelift-entity 0.130.2",
- "wasmtime-internal-core 43.0.2",
+ "cranelift-srcgen",
 ]
 
 [[package]]
@@ -1459,19 +1457,8 @@ version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5694aa8a2eb2571a15b3feee38d16ccaf2712200e7b5c9ae0479069bdfb46949"
 dependencies = [
- "cranelift-entity 0.132.1",
- "wasmtime-internal-core 45.0.1",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
-dependencies = [
- "serde",
- "serde_derive",
- "wasmtime-internal-core 43.0.2",
+ "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1482,35 +1469,7 @@ checksum = "93ab349d30a5fad9699440ee7ccb435374e8a8735dcca26696a4245bcefcc47e"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core 45.0.1",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.130.2",
- "cranelift-bforest 0.130.2",
- "cranelift-bitset 0.130.2",
- "cranelift-codegen-meta 0.130.2",
- "cranelift-codegen-shared 0.130.2",
- "cranelift-control 0.130.2",
- "cranelift-entity 0.130.2",
- "cranelift-isle 0.130.2",
- "gimli",
- "hashbrown 0.16.1",
- "libm",
- "log",
- "pulley-interpreter 43.0.2",
- "regalloc2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
- "wasmtime-internal-core 43.0.2",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1520,38 +1479,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e95970bdb51d145c828a114a1084cb8b63e65569a51600ad398cb49fa78b062"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.132.1",
- "cranelift-bforest 0.132.1",
- "cranelift-bitset 0.132.1",
- "cranelift-codegen-meta 0.132.1",
- "cranelift-codegen-shared 0.132.1",
- "cranelift-control 0.132.1",
- "cranelift-entity 0.132.1",
- "cranelift-isle 0.132.1",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "hashbrown 0.17.1",
  "libm",
  "log",
- "pulley-interpreter 45.0.1",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 45.0.1",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
-dependencies = [
- "cranelift-assembler-x64-meta 0.130.2",
- "cranelift-codegen-shared 0.130.2",
- "cranelift-srcgen 0.130.2",
- "heck",
- "pulley-interpreter 43.0.2",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1560,33 +1506,18 @@ version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e8414b8ecc81f89f8a3f2c5cbc785b9ed690200cd6f9d780e96a92f88879704"
 dependencies = [
- "cranelift-assembler-x64-meta 0.132.1",
- "cranelift-codegen-shared 0.132.1",
- "cranelift-srcgen 0.132.1",
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
  "heck",
- "pulley-interpreter 45.0.1",
+ "pulley-interpreter",
 ]
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
 
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631c4e5db42e6a0f9e7a68f18f7faba3692862114870c7c598aee7e0e5677e59"
-
-[[package]]
-name = "cranelift-control"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
-dependencies = [
- "arbitrary",
-]
 
 [[package]]
 name = "cranelift-control"
@@ -1599,38 +1530,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
-dependencies = [
- "cranelift-bitset 0.130.2",
- "serde",
- "serde_derive",
- "wasmtime-internal-core 43.0.2",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e57cd185782abada9ab2606bfe88d0abc0d42d83a7d432dcf69991e17fe76e"
 dependencies = [
- "cranelift-bitset 0.132.1",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
- "wasmtime-internal-core 45.0.1",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
-dependencies = [
- "cranelift-codegen 0.130.2",
- "log",
- "smallvec",
- "target-lexicon",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -1639,17 +1546,11 @@ version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0f17e48d15e29552e2f264d302c31a661a830196d879bbdaf4d7b2bf2f7011"
 dependencies = [
- "cranelift-codegen 0.132.1",
+ "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-isle"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
 
 [[package]]
 name = "cranelift-isle"
@@ -1659,31 +1560,14 @@ checksum = "407b80b46934c9dce9a6581f0e80d079b7a69e11372fb03d7dce4c7ba3fee4e3"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
-dependencies = [
- "cranelift-codegen 0.130.2",
- "libc",
- "target-lexicon",
-]
-
-[[package]]
-name = "cranelift-native"
 version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a40e056e421d9a6c757983f2184f765ae1c28a51555d3877e98afc97ce5705b"
 dependencies = [
- "cranelift-codegen 0.132.1",
+ "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.130.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
 
 [[package]]
 name = "cranelift-srcgen"
@@ -2794,14 +2678,15 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.1.27033365433"
+version = "0.1.27117617127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452d9cd2f98e1e43d9cd5c442dd0b8fa018961e95d12e818fd4e58aa9a3e3b18"
+checksum = "e3e32517b6f48139009ec02996c9d5fa9e48e948a1142a1997bed9e7940a35e8"
 dependencies = [
  "chrono",
  "greentic-config-types",
  "greentic-types",
  "hex",
+ "http 1.4.0",
  "semver",
  "serde",
  "serde_json",
@@ -2813,15 +2698,17 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.27033365433"
+version = "1.1.0-dev.27117617127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7ffcda6e6fb9c7c93daea72df30561672b783109c06d276bed1ba6909f1ef8"
+checksum = "80dfa298ebf2520ec5557f9e2f0de45a61ab56df2469a8e5e0c76e8c4ecef5fc"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
+ "aws-sdk-iam",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
+ "aws-sdk-sts",
  "aws-smithy-runtime-api",
  "chrono",
  "clap",
@@ -2929,8 +2816,8 @@ dependencies = [
  "tracing",
  "unic-langid",
  "url",
- "wasmtime 45.0.1",
- "wasmtime-environ 45.0.1",
+ "wasmtime",
+ "wasmtime-environ",
  "wasmtime-wasi",
 ]
 
@@ -2958,7 +2845,7 @@ dependencies = [
  "semver",
  "thiserror 2.0.18",
  "time",
- "wasmtime 45.0.1",
+ "wasmtime",
  "wit-bindgen 0.57.1",
  "wit-bindgen-core 0.57.1",
  "wit-bindgen-rust 0.57.1",
@@ -2987,7 +2874,7 @@ dependencies = [
  "greentic-types",
  "serde",
  "serde_json",
- "wasmtime 45.0.1",
+ "wasmtime",
 ]
 
 [[package]]
@@ -3003,7 +2890,7 @@ dependencies = [
  "quote",
  "syn",
  "walkdir",
- "wasmtime 45.0.1",
+ "wasmtime",
 ]
 
 [[package]]
@@ -3112,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-desktop"
-version = "1.1.0-dev.27007625967"
+version = "1.1.0-dev.27054682180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e024b8856e46081c7e84ffcf0e2261c34bcfd650359ac215262d4d61ec88bb1e"
+checksum = "c1585951df3fff3069792dd8ff017fdd24f4912e2e9a5e4b71178bb5af3475fb"
 dependencies = [
  "anyhow",
  "greentic-pack-lib",
@@ -3133,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-host"
-version = "1.1.0-dev.27007625967"
+version = "1.1.0-dev.27054682180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce693f75fe8bf6c5c86f493395a6167f9cd40f19221c0e4dee73c868f0d81c5e"
+checksum = "f73f87c559a376d9953fd7d5e5ca2ec3d941b7efd979ffdfccf12fb800619157"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3189,8 +3076,8 @@ dependencies = [
  "tracing",
  "url",
  "wasmparser 0.246.2",
- "wasmtime 45.0.1",
- "wasmtime-environ 45.0.1",
+ "wasmtime",
+ "wasmtime-environ",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
  "wasmtime-wasi-tls",
@@ -3310,9 +3197,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-setup"
-version = "1.1.0-dev.27012833285"
+version = "1.1.0-dev.27093775683"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13fa336301824eab4faabb4207262bb29d0f2b77e421a0024e49c520803fd79"
+checksum = "6787c574d7897d871e69bbc2f09ce758b26cca570175d19a9531366c58cf77cf"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -3348,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-start"
-version = "1.1.0-dev.27024967183"
+version = "1.1.0-dev.27095718510"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce2ba74c62e7d7acb0aff612005516a3c2761b828fd09e57408e2d79ed9dcc3"
+checksum = "069506231e6f13f5bc290eee13d611ac42a23b9b50175c466809e9080b80ebd5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3395,6 +3282,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_gtc",
  "sha2 0.11.0",
+ "subtle",
  "sys-locale",
  "sysinfo 0.39.2",
  "tar",
@@ -3411,7 +3299,7 @@ dependencies = [
  "ureq",
  "urlencoding",
  "uuid",
- "wasmtime 43.0.2",
+ "wasmtime",
  "zip 8.6.0",
  "zstd",
 ]
@@ -4789,18 +4677,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
-dependencies = [
- "crc32fast",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -5320,37 +5196,14 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
-dependencies = [
- "cranelift-bitset 0.130.2",
- "log",
- "pulley-macros 43.0.2",
- "wasmtime-internal-core 43.0.2",
-]
-
-[[package]]
-name = "pulley-interpreter"
 version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6ccdd6fc70f6c33eb21cb8fe05a71a5f7ee4cbef7a093a8a87dd8a908697cd"
 dependencies = [
- "cranelift-bitset 0.132.1",
+ "cranelift-bitset",
  "log",
- "pulley-macros 45.0.1",
- "wasmtime-internal-core 45.0.1",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pulley-macros",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -7460,16 +7313,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
@@ -7549,19 +7392,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
-dependencies = [
- "bitflags",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -7611,17 +7441,6 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasmprinter"
 version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
@@ -7629,48 +7448,6 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
-dependencies = [
- "addr2line",
- "async-trait",
- "bitflags",
- "bumpalo",
- "cc",
- "cfg-if",
- "encoding_rs",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object 0.38.1",
- "once_cell",
- "postcard",
- "pulley-interpreter 43.0.2",
- "rustix",
- "semver",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasmparser 0.245.1",
- "wasmtime-environ 43.0.2",
- "wasmtime-internal-component-macro 43.0.2",
- "wasmtime-internal-component-util 43.0.2",
- "wasmtime-internal-core 43.0.2",
- "wasmtime-internal-cranelift 43.0.2",
- "wasmtime-internal-fiber 43.0.2",
- "wasmtime-internal-jit-debug 43.0.2",
- "wasmtime-internal-jit-icache-coherence 43.0.2",
- "wasmtime-internal-unwinder 43.0.2",
- "wasmtime-internal-versioned-export-macros 43.0.2",
- "wasmtime-internal-winch 43.0.2",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7694,10 +7471,10 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object 0.39.1",
+ "object",
  "once_cell",
  "postcard",
- "pulley-interpreter 45.0.1",
+ "pulley-interpreter",
  "rayon",
  "rustix",
  "semver",
@@ -7710,49 +7487,20 @@ dependencies = [
  "wasm-compose",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
- "wasmtime-environ 45.0.1",
+ "wasmtime-environ",
  "wasmtime-internal-cache",
- "wasmtime-internal-component-macro 45.0.1",
- "wasmtime-internal-component-util 45.0.1",
- "wasmtime-internal-core 45.0.1",
- "wasmtime-internal-cranelift 45.0.1",
- "wasmtime-internal-fiber 45.0.1",
- "wasmtime-internal-jit-debug 45.0.1",
- "wasmtime-internal-jit-icache-coherence 45.0.1",
- "wasmtime-internal-unwinder 45.0.1",
- "wasmtime-internal-versioned-export-macros 45.0.1",
- "wasmtime-internal-winch 45.0.1",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
-dependencies = [
- "anyhow",
- "cranelift-bforest 0.130.2",
- "cranelift-bitset 0.130.2",
- "cranelift-entity 0.130.2",
- "gimli",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "log",
- "object 0.38.1",
- "postcard",
- "semver",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
- "wasmprinter 0.245.1",
- "wasmtime-internal-component-util 43.0.2",
- "wasmtime-internal-core 43.0.2",
 ]
 
 [[package]]
@@ -7763,14 +7511,14 @@ checksum = "0f337d68a62d868f3c297517b46d20dc7e293f0da36bbee2f6ec3c30eab938bd"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.132.1",
- "cranelift-bitset 0.132.1",
- "cranelift-entity 0.132.1",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
  "gimli",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "log",
- "object 0.39.1",
+ "object",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -7781,9 +7529,9 @@ dependencies = [
  "target-lexicon",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
- "wasmprinter 0.248.0",
- "wasmtime-internal-component-util 45.0.1",
- "wasmtime-internal-core 45.0.1",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -7801,24 +7549,9 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
- "wasmtime-environ 45.0.1",
+ "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
-]
-
-[[package]]
-name = "wasmtime-internal-component-macro"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5ec9fff073ff13b81732d56a9515d761c245750bcda09093827f84130ebc25"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn",
- "wasmtime-internal-component-util 43.0.2",
- "wasmtime-internal-wit-bindgen 43.0.2",
- "wit-parser 0.245.1",
 ]
 
 [[package]]
@@ -7831,33 +7564,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-internal-component-util 45.0.1",
- "wasmtime-internal-wit-bindgen 45.0.1",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
  "wit-parser 0.248.0",
 ]
-
-[[package]]
-name = "wasmtime-internal-component-util"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935d9ab293ba27d1ec9aa7bc1b3a43993dbe961af2a8f23f90a11e1331b4c13f"
 
 [[package]]
 name = "wasmtime-internal-component-util"
 version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f73ccd2e0e6bd91fb0161a17ee5e2d7badbeba6eb7461d0e0e3991492bd3835d"
-
-[[package]]
-name = "wasmtime-internal-core"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
-dependencies = [
- "hashbrown 0.16.1",
- "libm",
- "serde",
-]
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -7873,71 +7589,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.130.2",
- "cranelift-control 0.130.2",
- "cranelift-entity 0.130.2",
- "cranelift-frontend 0.130.2",
- "cranelift-native 0.130.2",
- "gimli",
- "itertools",
- "log",
- "object 0.38.1",
- "pulley-interpreter 43.0.2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
- "wasmtime-environ 43.0.2",
- "wasmtime-internal-core 43.0.2",
- "wasmtime-internal-unwinder 43.0.2",
- "wasmtime-internal-versioned-export-macros 43.0.2",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
 version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0236a21553c5b30ee953f413a8dc99729548b747219eef7e70f8288ed313ebe"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.132.1",
- "cranelift-control 0.132.1",
- "cranelift-entity 0.132.1",
- "cranelift-frontend 0.132.1",
- "cranelift-native 0.132.1",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
  "gimli",
  "itertools",
  "log",
- "object 0.39.1",
- "pulley-interpreter 45.0.1",
+ "object",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ 45.0.1",
- "wasmtime-internal-core 45.0.1",
- "wasmtime-internal-unwinder 45.0.1",
- "wasmtime-internal-versioned-export-macros 45.0.1",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "rustix",
- "wasmtime-environ 43.0.2",
- "wasmtime-internal-versioned-export-macros 43.0.2",
- "windows-sys 0.61.2",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -7950,19 +7624,9 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ 45.0.1",
- "wasmtime-internal-versioned-export-macros 45.0.1",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
-dependencies = [
- "cc",
- "wasmtime-internal-versioned-export-macros 43.0.2",
 ]
 
 [[package]]
@@ -7972,21 +7636,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a52ca7429272234b44f81fdf80d4793593e5c368b0f960d41fd401b1117bec"
 dependencies = [
  "cc",
- "object 0.39.1",
+ "object",
  "rustix",
- "wasmtime-internal-versioned-export-macros 45.0.1",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
-dependencies = [
- "cfg-if",
- "libc",
- "wasmtime-internal-core 43.0.2",
- "windows-sys 0.61.2",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
@@ -7997,21 +7649,8 @@ checksum = "aa6818a4864719772680694f4e4649a8600bb5efcf71111ebaf7419b266463e8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 45.0.1",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
-dependencies = [
- "cfg-if",
- "cranelift-codegen 0.130.2",
- "log",
- "object 0.38.1",
- "wasmtime-environ 43.0.2",
 ]
 
 [[package]]
@@ -8021,21 +7660,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdc6a69c42fbbf13104ccbf0d3c096d0392f00102e2c70b542d9fca402eb162"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.132.1",
+ "cranelift-codegen",
  "log",
- "object 0.39.1",
- "wasmtime-environ 45.0.1",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "object",
+ "wasmtime-environ",
 ]
 
 [[package]]
@@ -8051,49 +7679,19 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
-dependencies = [
- "cranelift-codegen 0.130.2",
- "gimli",
- "log",
- "object 0.38.1",
- "target-lexicon",
- "wasmparser 0.245.1",
- "wasmtime-environ 43.0.2",
- "wasmtime-internal-cranelift 43.0.2",
- "winch-codegen 43.0.2",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
 version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2ca01234ef55acd10c0fa5a2f96c3fd422eba03b221e2e9572944d19a476a7"
 dependencies = [
- "cranelift-codegen 0.132.1",
+ "cranelift-codegen",
  "gimli",
  "log",
- "object 0.39.1",
+ "object",
  "target-lexicon",
  "wasmparser 0.248.0",
- "wasmtime-environ 45.0.1",
- "wasmtime-internal-cranelift 45.0.1",
- "winch-codegen 45.0.1",
-]
-
-[[package]]
-name = "wasmtime-internal-wit-bindgen"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
-dependencies = [
- "anyhow",
- "bitflags",
- "heck",
- "indexmap 2.14.0",
- "wit-parser 0.245.1",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
 ]
 
 [[package]]
@@ -8133,7 +7731,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtime 45.0.1",
+ "wasmtime",
  "wasmtime-wasi-io",
  "wiggle",
  "windows-sys 0.61.2",
@@ -8156,7 +7754,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "wasmtime 45.0.1",
+ "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
  "webpki-roots 0.26.11",
@@ -8172,7 +7770,7 @@ dependencies = [
  "bytes",
  "futures",
  "tracing",
- "wasmtime 45.0.1",
+ "wasmtime",
 ]
 
 [[package]]
@@ -8186,7 +7784,7 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "wasmtime 45.0.1",
+ "wasmtime",
  "wasmtime-wasi",
  "webpki-roots 0.26.11",
 ]
@@ -8278,8 +7876,8 @@ dependencies = [
  "bitflags",
  "thiserror 2.0.18",
  "tracing",
- "wasmtime 45.0.1",
- "wasmtime-environ 45.0.1",
+ "wasmtime",
+ "wasmtime-environ",
  "wiggle-macro",
 ]
 
@@ -8293,7 +7891,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wasmtime-environ 45.0.1",
+ "wasmtime-environ",
  "witx",
 ]
 
@@ -8342,40 +7940,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
-dependencies = [
- "cranelift-assembler-x64 0.130.2",
- "cranelift-codegen 0.130.2",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
- "wasmtime-environ 43.0.2",
- "wasmtime-internal-core 43.0.2",
- "wasmtime-internal-cranelift 43.0.2",
-]
-
-[[package]]
-name = "winch-codegen"
 version = "45.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fdfab04a4d446c558a9ea994ded662d35580a17b15385b862002703aa43245"
 dependencies = [
- "cranelift-assembler-x64 0.132.1",
- "cranelift-codegen 0.132.1",
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
  "gimli",
  "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
  "wasmparser 0.248.0",
- "wasmtime-environ 45.0.1",
- "wasmtime-internal-core 45.0.1",
- "wasmtime-internal-cranelift 45.0.1",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
 ]
 
 [[package]]
@@ -8848,25 +8427,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330698718e82983499419494dd1e3d7811a457a9bf9f69734e8c5f07a2547929"
-dependencies = [
- "anyhow",
- "hashbrown 0.16.1",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.245.1",
 ]
 
 [[package]]

--- a/src/demo/runner.rs
+++ b/src/demo/runner.rs
@@ -192,6 +192,7 @@ fn build_host_config(tenant: &str) -> HostConfig {
         trace: TraceConfig::from_env(),
         validation: ValidationConfig::from_env(),
         operator_policy: OperatorPolicy::allow_all(),
+        fast2flow: Default::default(),
     }
 }
 

--- a/src/demo/runner_host.rs
+++ b/src/demo/runner_host.rs
@@ -1351,6 +1351,7 @@ fn build_demo_host_config(tenant: &str) -> HostConfig {
         trace: TraceConfig::from_env(),
         validation: ValidationConfig::from_env(),
         operator_policy: OperatorPolicy::allow_all(),
+        fast2flow: Default::default(),
     }
 }
 

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -840,6 +840,7 @@ mod tests {
                 region: None,
                 tenant_org_id: None,
                 listen_addr: None,
+                public_base_url: None,
             },
             packs: Vec::new(),
             credentials_ref: None,

--- a/tests/demo_events_up.rs
+++ b/tests/demo_events_up.rs
@@ -152,6 +152,7 @@ services:
         None,
         None,
         None,
+        None,
         &BTreeSet::new(),
         None,
         &log_dir,

--- a/tests/demo_up_smoke.rs
+++ b/tests/demo_up_smoke.rs
@@ -53,6 +53,7 @@ services:
         None,
         None,
         None,
+        None,
         &BTreeSet::new(),
         None,
         &log_dir,


### PR DESCRIPTION
## Summary

- Roll the lockfile forward and adopt source-level changes so `gtc op deploy --answers ...` accepts `route_binding` inline (no follow-up `op bundles update`).
- Verified locally: `gtc-dev op deploy --schema | jq '.result.properties | keys'` now lists `route_binding`; one-line deploys against `realbot-legal`/`realbot-accounting` succeed and persist `path_prefixes` + `tenant_selector`.

## Lockfile bumps

| crate | from → to | what it unblocks |
|---|---|---|
| `greentic-deployer` | 27033365433 → 27117617127 | `BundleDeployPayload.route_binding` + `config_overrides` |
| `greentic-deploy-spec` | 27033365433 → 27117617127 | `validate_public_base_url`, `EnvironmentHostConfig.public_base_url` |
| `greentic-setup` | 27012833285 → 27093775683 | `ensure_local_environment(&store, Option<String>)` |
| `greentic-start` | 27024967183 → 27095718510 | same setup-helper signature; drops wasmtime 43 in favor of 45 |
| `greentic-runner-host/desktop` | 27007625967 → 27054682180 | `HostConfig.fast2flow` |

## Source-side fixups

- `src/demo/{runner,runner_host}.rs` — HostConfig literal: `fast2flow: Default::default()`
- `src/deployments/api.rs` — test EnvironmentHostConfig literal: `public_base_url: None`
- `tests/demo_{up_smoke,events_up}.rs` — `demo_up_services` gained a second `Option<String>` URL slot (env-store public_base_url); pass `None`

## Test plan

- [x] `bash ci/local_check.sh` — green (lib build + tests + binstall artifact)
- [x] `gtc-dev op deploy --schema | jq '.result.properties | keys'` includes `route_binding`
- [x] `gtc-dev op deploy --answers '{..., "route_binding":{...}}'` on a fresh bundle_id persists routing (verified with probe deployment routed to `/probe` w/ `tenant=probe`)
- [x] Re-deploy of an existing bundle with matching route_binding succeeds with `reused: true, status: "routed"`
- [x] Re-deploy of an existing bundle with a *different* route_binding returns `Conflict` (the gate works)

## Why this PR

A previous attempt to use `op deploy --answers ... route_binding` silently no-op'd because the installed `greentic-operator-dev 1.1.26960746918` was built on 2026-06-04, against deployer 1.1.0-dev.27033 which didn't yet expose the field. Serde silently dropped the unknown JSON property and the demo's two Telegram bots ended up with empty `path_prefixes` and `tenant=default`. Republishing operator-dev with these bumps closes the gap.