### PR TITLE
C7: greentic-operator qa_persist emits pack-config-input.v1 (PR3)

### DIFF
--- a/src/qa_persist.rs
+++ b/src/qa_persist.rs
@@ -1,17 +1,28 @@
 //! Persist config and secrets from QA apply-answers output.
 //!
 //! After a provider's `apply-answers` op returns a config object, this module:
-//! - Extracts secret fields (identified by `FormSpec.questions[].secret == true`)
-//!   and writes them to the dev secrets store.
+//! - Writes every visible answer to the dev secrets store under
+//!   `secrets://<env>/<tenant>/<team>/<provider>/<key>` (legacy universal
+//!   write — WASM components have historically read both secret and
+//!   non-secret config values through the secrets API).
+//! - Emits a sibling `pack-config-input.v1` file via
+//!   [`emit_pack_config_input`] when the wizard scope is known. This is the
+//!   C7 producer for the `pack-config.v1.non_secret` channel: the
+//!   greentic-deployer picks up the file at revision-create, stamps the
+//!   active `revision_id`, and writes the final `pack-config.v1` consumed by
+//!   the runtime (C4). The universal DevStore write stays alive for one
+//!   release as the C4.2 compatibility shim.
 //! - Writes remaining (non-secret) fields to the provider config envelope.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use greentic_secrets_lib::{
     ApplyOptions, DevStore, SecretFormat, SeedDoc, SeedEntry, SeedValue, apply_seed,
 };
-use qa_spec::FormSpec;
+use qa_spec::{FormSpec, VisibilityMode, resolve_visibility};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value};
 
 use crate::secrets_gate::canonical_secret_uri;
@@ -29,11 +40,19 @@ pub async fn persist_qa_secrets(
     config: &Value,
     form_spec: &FormSpec,
 ) -> Result<Vec<String>> {
-    // Collect all question IDs — WASM components read both secret and non-secret
-    // config values via the secrets API, so we must persist everything.
-    let all_question_ids: Vec<&str> = form_spec.questions.iter().map(|q| q.id.as_str()).collect();
+    // Collect visible question IDs — WASM components read both secret and
+    // non-secret config values via the secrets API, so we must persist
+    // everything that is currently visible (skip conditionally-invisible
+    // questions to avoid leaking stale answers).
+    let visibility = resolve_visibility(form_spec, config, VisibilityMode::Visible);
+    let visible_question_ids: Vec<&str> = form_spec
+        .questions
+        .iter()
+        .filter(|q| visibility.get(&q.id).copied().unwrap_or(true))
+        .map(|q| q.id.as_str())
+        .collect();
 
-    if all_question_ids.is_empty() {
+    if visible_question_ids.is_empty() {
         return Ok(vec![]);
     }
 
@@ -44,7 +63,7 @@ pub async fn persist_qa_secrets(
     let mut entries = Vec::new();
     let mut saved_keys = Vec::new();
 
-    for &key in &all_question_ids {
+    for &key in &visible_question_ids {
         if let Some(value) = config_map.get(key) {
             let text = match value {
                 Value::String(s) => s.clone(),
@@ -214,6 +233,13 @@ pub async fn persist_all_config_as_secrets(
         ));
     }
 
+    // C7: emit `pack-config-input.v1` for the deployer when a pack is on hand
+    // and a FormSpec can be derived. Soft-fail — the C4.2 compat shim still
+    // serves these keys from DevStore (just populated above).
+    if let Some(pp) = pack_path {
+        try_emit_pack_config_input(bundle_root, pp, env, provider_id, config);
+    }
+
     Ok(saved_keys)
 }
 
@@ -316,6 +342,29 @@ pub async fn persist_qa_results(
     let saved_secrets =
         persist_qa_secrets(&store, &env, tenant, team, provider_id, config, form_spec).await?;
 
+    // C7: emit `pack-config-input.v1` so the deployer can populate the
+    // `pack-config.v1.non_secret` channel at revision-create. Soft-fail —
+    // the C4.2 compat shim still serves these keys from DevStore (already
+    // populated above), so a wizard run does not regress on emit failure.
+    let bundle_id = infer_bundle_id(bundle_root);
+    if let Err(err) = emit_pack_config_input(
+        bundle_root,
+        &env,
+        &bundle_id,
+        provider_id,
+        config,
+        form_spec,
+    ) {
+        tracing::warn!(
+            provider_id,
+            env = %env,
+            bundle_id = %bundle_id,
+            bundle_root = %bundle_root.display(),
+            error = %err,
+            "pack-config-input emission failed; runtime falls back to legacy DevStore reads via C4.2 compat shim",
+        );
+    }
+
     let config_written = if config.as_object().is_some_and(|m| !m.is_empty()) {
         persist_qa_config(
             providers_root,
@@ -347,6 +396,205 @@ pub fn oauth_authorize_stub(provider_id: &str, auth_url: Option<&str>) -> Option
         println!("[oauth] OAuth integration is not yet implemented.");
     }
     None
+}
+
+// ── pack-config-input.v1 emitter (C7) ──────────────────────────────────────
+
+/// Schema tag for the wizard-emitted intermediate file consumed by the
+/// greentic-deployer at revision-create.
+pub const PACK_CONFIG_INPUT_SCHEMA: &str = "greentic.pack-config-input.v1";
+
+/// Directory under `bundle_root` where wizard-emitted pack-config inputs land.
+/// The deployer joins on `<bundle_root>/<PACK_CONFIG_INPUT_DIR>/<pack_id>.json`
+/// at revision-create.
+pub const PACK_CONFIG_INPUT_DIR: &str = "state/pack-configs";
+
+/// Wizard-emitted intermediate file the deployer picks up at revision-create
+/// (C7). The deployer stamps the active `revision_id` and writes the final
+/// `pack-config.v1` referenced by `pack_config_refs` in `runtime-config.v1`.
+/// We keep `revision_id` OUT of this shape on purpose: revisions are minted
+/// by the deployer, not the wizard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackConfigInput {
+    pub schema: String,
+    pub pack_id: String,
+    pub env_id: String,
+    pub bundle_id: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub non_secret: BTreeMap<String, Value>,
+    /// `secret://<env>/<bundle>/<pack>/<question>` URIs (kept as plain
+    /// strings here — `greentic-deploy-spec::SecretRef` validates at the
+    /// deployer side when it materializes the final `pack-config.v1`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub secret_refs: BTreeMap<String, String>,
+}
+
+/// Emit a `pack-config-input.v1` file at
+/// `<bundle_root>/state/pack-configs/<pack_id>.json` carrying the FormSpec-
+/// split of one provider's QA answers (C7). Idempotent: overwrites in place
+/// so re-running the wizard produces the same on-disk shape.
+///
+/// Secret-marked answers are recorded as `secret://<env>/<bundle>/<pack>/<key>`
+/// URI references (no plaintext); non-secret answers stay inline. Empty
+/// `config` is a no-op (no file written).
+pub fn emit_pack_config_input(
+    bundle_root: &Path,
+    env_id: &str,
+    bundle_id: &str,
+    pack_id: &str,
+    config: &Value,
+    form_spec: &FormSpec,
+) -> Result<Option<std::path::PathBuf>> {
+    validate_segment("env_id", env_id)?;
+    validate_segment("bundle_id", bundle_id)?;
+    validate_segment("pack_id", pack_id)?;
+
+    let Some(config_map) = config.as_object() else {
+        return Ok(None);
+    };
+    if config_map.is_empty() {
+        return Ok(None);
+    }
+
+    // Apply the same visibility filter that `persist_qa_secrets` uses so
+    // that conditionally-invisible answers do not leak into the
+    // pack-config-input file (and from there into runtime config).
+    let visibility = resolve_visibility(form_spec, config, VisibilityMode::Visible);
+
+    let secret_ids: std::collections::HashSet<&str> = form_spec
+        .questions
+        .iter()
+        .filter(|q| q.secret)
+        .map(|q| q.id.as_str())
+        .collect();
+
+    let visible_ids: std::collections::HashSet<&str> = form_spec
+        .questions
+        .iter()
+        .filter(|q| visibility.get(&q.id).copied().unwrap_or(true))
+        .map(|q| q.id.as_str())
+        .collect();
+
+    let mut non_secret = BTreeMap::new();
+    let mut secret_refs = BTreeMap::new();
+    for (key, value) in config_map {
+        if !visible_ids.contains(key.as_str()) {
+            continue;
+        }
+        let text = match value {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        if text.is_empty() || text == "null" {
+            continue;
+        }
+        if secret_ids.contains(key.as_str()) {
+            validate_segment("question.id", key)?;
+            let uri = format!("secret://{env_id}/{bundle_id}/{pack_id}/{key}");
+            secret_refs.insert(key.clone(), uri);
+        } else {
+            non_secret.insert(key.clone(), value.clone());
+        }
+    }
+
+    if non_secret.is_empty() && secret_refs.is_empty() {
+        return Ok(None);
+    }
+
+    let input = PackConfigInput {
+        schema: PACK_CONFIG_INPUT_SCHEMA.to_string(),
+        pack_id: pack_id.to_string(),
+        env_id: env_id.to_string(),
+        bundle_id: bundle_id.to_string(),
+        non_secret,
+        secret_refs,
+    };
+
+    let dir = bundle_root.join(PACK_CONFIG_INPUT_DIR);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create pack-config-input dir {}", dir.display()))?;
+    let path = dir.join(format!("{pack_id}.json"));
+    let body = serde_json::to_string_pretty(&input).context("serialize pack-config-input.v1")?;
+    std::fs::write(&path, format!("{body}\n"))
+        .with_context(|| format!("write pack-config-input {}", path.display()))?;
+
+    tracing::debug!(
+        pack_id,
+        env_id,
+        bundle_id,
+        non_secret_count = input.non_secret.len(),
+        secret_ref_count = input.secret_refs.len(),
+        path = %path.display(),
+        "wizard emitted pack-config-input.v1 (C7) for deployer pickup",
+    );
+    Ok(Some(path))
+}
+
+/// Reject empty, `/`-bearing, or relative-component (`.`, `..`) identifiers —
+/// these would silently corrupt the `secret://<env>/<bundle>/<pack>/<question>`
+/// path structure or the `<dir>/<pack_id>.json` file path.
+fn validate_segment(label: &str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        anyhow::bail!("{label} must not be empty for pack-config-input emission");
+    }
+    if value.contains('/') {
+        anyhow::bail!(
+            "{label} `{value}` contains '/' which would corrupt the pack-config-input layout"
+        );
+    }
+    if value == "." || value == ".." {
+        anyhow::bail!(
+            "{label} `{value}` is a relative path component and would corrupt the pack-config-input layout"
+        );
+    }
+    Ok(())
+}
+
+/// Derive a stable bundle id from the bundle root path, with a `"bundle"`
+/// fallback when the directory name is missing or empty.
+pub(crate) fn infer_bundle_id(root: &Path) -> String {
+    root.file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "bundle".to_string())
+}
+
+/// C7: attempt to emit a `pack-config-input.v1` file for one provider when
+/// a FormSpec can be derived from the on-disk pack. Soft-fails on missing
+/// FormSpec or emission error — the C4.2 compat shim still serves these
+/// keys from DevStore.
+fn try_emit_pack_config_input(
+    bundle_root: &Path,
+    pack_path: &Path,
+    env: &str,
+    provider_id: &str,
+    answers: &Value,
+) {
+    let Some(form_spec) =
+        greentic_setup::setup_to_formspec::pack_to_form_spec(pack_path, provider_id)
+    else {
+        return;
+    };
+    let bundle_id = infer_bundle_id(bundle_root);
+    if let Err(err) = emit_pack_config_input(
+        bundle_root,
+        env,
+        &bundle_id,
+        provider_id,
+        answers,
+        &form_spec,
+    ) {
+        tracing::warn!(
+            provider_id,
+            env = %env,
+            bundle_id = %bundle_id,
+            bundle_root = %bundle_root.display(),
+            pack_path = %pack_path.display(),
+            error = %err,
+            "pack-config-input emission failed; runtime falls back to legacy DevStore reads via C4.2 compat shim",
+        );
+    }
 }
 
 #[cfg(test)]
@@ -428,5 +676,178 @@ mod tests {
             .map(|q| q.id.as_str())
             .collect();
         assert_eq!(secret_ids, vec!["bot_token", "api_secret"]);
+    }
+
+    // ── C7: pack-config-input.v1 emitter ──────────────────────────────────
+
+    /// Secrets land as `secret://` URI refs (no plaintext); non-secrets stay
+    /// inline. Empty config → no file written.
+    #[test]
+    fn emit_pack_config_input_splits_secret_vs_non_secret() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![
+            question("enabled", false),
+            question("bot_token", true),
+            question("public_url", false),
+        ]);
+        let config = json!({
+            "enabled": true,
+            "bot_token": "shhh",
+            "public_url": "https://example.com",
+        });
+        let path =
+            emit_pack_config_input(root, "local", "test-bundle", "provider-a", &config, &form)
+                .expect("emit")
+                .expect("path");
+        assert!(path.exists());
+        let bytes = std::fs::read(&path).expect("read");
+        let parsed: PackConfigInput = serde_json::from_slice(&bytes).expect("parse");
+        assert_eq!(parsed.schema, PACK_CONFIG_INPUT_SCHEMA);
+        assert_eq!(parsed.pack_id, "provider-a");
+        assert_eq!(parsed.env_id, "local");
+        assert_eq!(parsed.bundle_id, "test-bundle");
+        assert_eq!(parsed.non_secret.get("enabled"), Some(&Value::Bool(true)));
+        assert_eq!(
+            parsed.non_secret.get("public_url"),
+            Some(&Value::String("https://example.com".into())),
+        );
+        assert!(
+            !parsed.non_secret.contains_key("bot_token"),
+            "secret must not be in non_secret"
+        );
+        assert_eq!(
+            parsed.secret_refs.get("bot_token").map(String::as_str),
+            Some("secret://local/test-bundle/provider-a/bot_token"),
+            "secret recorded as URI ref"
+        );
+        // No plaintext for the secret anywhere in the file.
+        let body = String::from_utf8(bytes).expect("utf8");
+        assert!(
+            !body.contains("shhh"),
+            "plaintext secret leaked into pack-config-input: {body}"
+        );
+    }
+
+    /// Same answers + same bundle_id + same provider_id, different env_id →
+    /// different secret_refs. Pins the env-segment integrity of the URI.
+    #[test]
+    fn emit_pack_config_input_secret_refs_discriminate_on_env_id() {
+        let tmp_a = tempfile::TempDir::new().expect("tempdir-a");
+        let tmp_b = tempfile::TempDir::new().expect("tempdir-b");
+        let form = make_form_spec(vec![question("api_token", true)]);
+        let cfg = json!({"api_token": "x"});
+        let pa = emit_pack_config_input(tmp_a.path(), "local", "b", "p", &cfg, &form)
+            .expect("emit-a")
+            .expect("path-a");
+        let pb = emit_pack_config_input(tmp_b.path(), "staging", "b", "p", &cfg, &form)
+            .expect("emit-b")
+            .expect("path-b");
+        let parsed_a: PackConfigInput =
+            serde_json::from_slice(&std::fs::read(&pa).unwrap()).unwrap();
+        let parsed_b: PackConfigInput =
+            serde_json::from_slice(&std::fs::read(&pb).unwrap()).unwrap();
+        assert_eq!(
+            parsed_a.secret_refs.get("api_token").map(String::as_str),
+            Some("secret://local/b/p/api_token")
+        );
+        assert_eq!(
+            parsed_b.secret_refs.get("api_token").map(String::as_str),
+            Some("secret://staging/b/p/api_token")
+        );
+    }
+
+    /// Empty config → no file written (caller treats `Ok(None)` as no-op).
+    #[test]
+    fn emit_pack_config_input_skips_empty_config() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![question("enabled", false)]);
+        let empty = json!({});
+        assert!(
+            emit_pack_config_input(root, "local", "b", "p", &empty, &form)
+                .expect("emit")
+                .is_none()
+        );
+        assert!(!root.join(PACK_CONFIG_INPUT_DIR).exists());
+    }
+
+    /// Reject `/`-bearing, empty, or relative-component path segments —
+    /// `secret://` URI integrity + on-disk `<dir>/<pack_id>.json` layout
+    /// depend on it.
+    #[test]
+    fn emit_pack_config_input_rejects_invalid_segments() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![question("k", false)]);
+        let cfg = json!({"k": "v"});
+        assert!(
+            emit_pack_config_input(root, "", "b", "p", &cfg, &form).is_err(),
+            "empty env_id rejected"
+        );
+        assert!(
+            emit_pack_config_input(root, "local", "b", "../p", &cfg, &form).is_err(),
+            "pack_id with `/` rejected"
+        );
+        assert!(
+            emit_pack_config_input(root, "local", "b/c", "p", &cfg, &form).is_err(),
+            "bundle_id with `/` rejected"
+        );
+        assert!(
+            emit_pack_config_input(root, "local", "b", "..", &cfg, &form).is_err(),
+            "pack_id `..` rejected"
+        );
+        assert!(
+            emit_pack_config_input(root, ".", "b", "p", &cfg, &form).is_err(),
+            "env_id `.` rejected"
+        );
+    }
+
+    /// Invisible questions (conditional `visible_if` that evaluates to false)
+    /// must not leak into the pack-config-input file.
+    #[test]
+    fn emit_pack_config_input_respects_visibility() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![question("mode", false), {
+            let mut q = question("advanced_url", false);
+            q.visible_if = Some(qa_spec::Expr::Eq {
+                left: Box::new(qa_spec::Expr::Answer {
+                    path: "mode".into(),
+                }),
+                right: Box::new(qa_spec::Expr::Literal {
+                    value: Value::String("advanced".into()),
+                }),
+            });
+            q
+        }]);
+        let config = json!({
+            "mode": "basic",
+            "advanced_url": "https://should-be-hidden.example.com",
+        });
+        let path = emit_pack_config_input(root, "local", "b", "p", &config, &form)
+            .expect("emit")
+            .expect("path");
+        let parsed: PackConfigInput =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(
+            !parsed.non_secret.contains_key("advanced_url"),
+            "invisible question should not appear in non_secret: {parsed:?}"
+        );
+        assert_eq!(
+            parsed.non_secret.get("mode"),
+            Some(&Value::String("basic".into())),
+        );
+    }
+
+    /// `infer_bundle_id` returns the directory name, with `"bundle"`
+    /// fallback when the root has no usable file name.
+    #[test]
+    fn infer_bundle_id_uses_dir_name_with_bundle_fallback() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let nested = tmp.path().join("my-bundle");
+        std::fs::create_dir_all(&nested).expect("nested");
+        assert_eq!(infer_bundle_id(&nested), "my-bundle");
+        assert_eq!(infer_bundle_id(Path::new("/")), "bundle");
     }
 }

--- a/src/qa_persist.rs
+++ b/src/qa_persist.rs
@@ -342,9 +342,25 @@ pub async fn persist_qa_results(
     let saved_secrets =
         persist_qa_secrets(&store, &env, tenant, team, provider_id, config, form_spec).await?;
 
+    let config_written = if config.as_object().is_some_and(|m| !m.is_empty()) {
+        persist_qa_config(
+            providers_root,
+            provider_id,
+            config,
+            pack_path,
+            form_spec,
+            backup,
+        )?;
+        true
+    } else {
+        false
+    };
+
     // C7: emit `pack-config-input.v1` so the deployer can populate the
-    // `pack-config.v1.non_secret` channel at revision-create. Soft-fail —
-    // the C4.2 compat shim still serves these keys from DevStore (already
+    // `pack-config.v1.non_secret` channel at revision-create. Runs AFTER
+    // persist_qa_config so a config-write failure aborts before any C7
+    // artifact lands on disk. Emit failures soft-fail with a warn — the
+    // C4.2 compat shim still serves these keys from DevStore (already
     // populated above), so a wizard run does not regress on emit failure.
     let bundle_id = infer_bundle_id(bundle_root);
     if let Err(err) = emit_pack_config_input(
@@ -364,20 +380,6 @@ pub async fn persist_qa_results(
             "pack-config-input emission failed; runtime falls back to legacy DevStore reads via C4.2 compat shim",
         );
     }
-
-    let config_written = if config.as_object().is_some_and(|m| !m.is_empty()) {
-        persist_qa_config(
-            providers_root,
-            provider_id,
-            config,
-            pack_path,
-            form_spec,
-            backup,
-        )?;
-        true
-    } else {
-        false
-    };
 
     Ok((saved_secrets, config_written))
 }
@@ -449,10 +451,20 @@ pub fn emit_pack_config_input(
     validate_segment("bundle_id", bundle_id)?;
     validate_segment("pack_id", pack_id)?;
 
+    // Pre-compute the on-disk path so every Ok(None) early-return path can
+    // tombstone any stale file left behind by an earlier wizard run that
+    // had visible/non-empty answers. Without this, clearing answers (or
+    // hiding them via `visible_if`) would leave the previous file for the
+    // deployer to consume on the next revision-create.
+    let dir = bundle_root.join(PACK_CONFIG_INPUT_DIR);
+    let path = dir.join(format!("{pack_id}.json"));
+
     let Some(config_map) = config.as_object() else {
+        remove_stale_pack_config_input(&path)?;
         return Ok(None);
     };
     if config_map.is_empty() {
+        remove_stale_pack_config_input(&path)?;
         return Ok(None);
     }
 
@@ -498,6 +510,7 @@ pub fn emit_pack_config_input(
     }
 
     if non_secret.is_empty() && secret_refs.is_empty() {
+        remove_stale_pack_config_input(&path)?;
         return Ok(None);
     }
 
@@ -510,10 +523,8 @@ pub fn emit_pack_config_input(
         secret_refs,
     };
 
-    let dir = bundle_root.join(PACK_CONFIG_INPUT_DIR);
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create pack-config-input dir {}", dir.display()))?;
-    let path = dir.join(format!("{pack_id}.json"));
     let body = serde_json::to_string_pretty(&input).context("serialize pack-config-input.v1")?;
     std::fs::write(&path, format!("{body}\n"))
         .with_context(|| format!("write pack-config-input {}", path.display()))?;
@@ -528,6 +539,25 @@ pub fn emit_pack_config_input(
         "wizard emitted pack-config-input.v1 (C7) for deployer pickup",
     );
     Ok(Some(path))
+}
+
+/// Remove a stale pack-config-input file when the current wizard state has
+/// no visible/non-empty entries. Returns `Ok(())` if the file is already
+/// gone (NotFound). Any other I/O error propagates so the caller sees the
+/// staleness risk instead of silently emitting an inconsistent revision.
+fn remove_stale_pack_config_input(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => {
+            tracing::debug!(
+                path = %path.display(),
+                "removed stale pack-config-input.v1 (current answers produced no entries)"
+            );
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(anyhow::Error::from(err))
+            .with_context(|| format!("remove stale pack-config-input {}", path.display())),
+    }
 }
 
 /// Reject empty, `/`-bearing, or relative-component (`.`, `..`) identifiers —
@@ -849,5 +879,102 @@ mod tests {
         std::fs::create_dir_all(&nested).expect("nested");
         assert_eq!(infer_bundle_id(&nested), "my-bundle");
         assert_eq!(infer_bundle_id(Path::new("/")), "bundle");
+    }
+
+    /// Stale-file cleanup: when an earlier wizard run wrote a
+    /// pack-config-input.v1 file and a subsequent run produces no visible /
+    /// non-empty entries, the existing file must be removed so the deployer
+    /// does not pick up stale answers on the next revision-create.
+    #[test]
+    fn emit_pack_config_input_removes_stale_file_when_answers_clear() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![question("enabled", false)]);
+
+        // First run: produces a file.
+        let path =
+            emit_pack_config_input(root, "local", "b", "p", &json!({"enabled": true}), &form)
+                .expect("emit-first")
+                .expect("path");
+        assert!(path.exists(), "first run must write the file");
+
+        // Second run: empty config → file must be removed.
+        let empty = json!({});
+        assert!(
+            emit_pack_config_input(root, "local", "b", "p", &empty, &form)
+                .expect("emit-empty")
+                .is_none(),
+            "empty config returns Ok(None)"
+        );
+        assert!(
+            !path.exists(),
+            "stale pack-config-input survived after empty re-run: {}",
+            path.display()
+        );
+
+        // Third run: rewrite, then a run where every value is empty/null →
+        // file must again be removed (covers the post-filter Ok(None) path).
+        emit_pack_config_input(root, "local", "b", "p", &json!({"enabled": true}), &form)
+            .expect("emit-third")
+            .expect("path-third");
+        assert!(path.exists());
+        assert!(
+            emit_pack_config_input(root, "local", "b", "p", &json!({"enabled": ""}), &form)
+                .expect("emit-blank")
+                .is_none(),
+            "all-empty config returns Ok(None)"
+        );
+        assert!(
+            !path.exists(),
+            "stale pack-config-input survived after all-empty re-run: {}",
+            path.display()
+        );
+    }
+
+    /// Visibility-driven empty result also tombstones any stale file.
+    #[test]
+    fn emit_pack_config_input_removes_stale_file_when_visibility_clears_all() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        let form = make_form_spec(vec![question("mode", false), {
+            let mut q = question("token", true);
+            q.visible_if = Some(qa_spec::Expr::Eq {
+                left: Box::new(qa_spec::Expr::Answer {
+                    path: "mode".into(),
+                }),
+                right: Box::new(qa_spec::Expr::Literal {
+                    value: Value::String("advanced".into()),
+                }),
+            });
+            q
+        }]);
+
+        // First run: mode=advanced → token visible → file written.
+        let path = emit_pack_config_input(
+            root,
+            "local",
+            "b",
+            "p",
+            &json!({"mode": "advanced", "token": "shhh"}),
+            &form,
+        )
+        .expect("emit-first")
+        .expect("path");
+        assert!(path.exists());
+
+        // Second run: mode=basic → token hidden → only `mode` visible.
+        // Re-emit succeeds (mode still present); now flip to a config where
+        // even `mode` is absent so every visible answer is filtered out.
+        let absent = json!({});
+        assert!(
+            emit_pack_config_input(root, "local", "b", "p", &absent, &form)
+                .expect("emit-absent")
+                .is_none()
+        );
+        assert!(
+            !path.exists(),
+            "stale pack-config-input survived after visibility-empty re-run: {}",
+            path.display()
+        );
     }
 }


### PR DESCRIPTION
## Summary

C7 PR3 (operator half). Mirrors greentic-setup PR2 into greentic-operator's `qa_persist` so operator wizard + setup-input flows feed the C4 `pack-config.v1` channel via the deployer pickup at revision-create.

PR2 (greentic-setup #135) added the producer for the setup wizard; this PR adds the equivalent for greentic-operator. PR4 (greentic-deployer) is the consumer that stamps `revision_id` and materializes the final `pack-config.v1`.

## Module surface

- `PACK_CONFIG_INPUT_SCHEMA` / `PACK_CONFIG_INPUT_DIR` constants
- `PackConfigInput` struct — `schema` / `pack_id` / `env_id` / `bundle_id` / `non_secret` / `secret_refs`. `revision_id` deliberately out: revisions are minted by the deployer, not the wizard.
- `emit_pack_config_input(bundle_root, env_id, bundle_id, pack_id, config, form_spec)` — splits answers by FormSpec `secret:true`, writes `<bundle_root>/state/pack-configs/<pack_id>.json`. Secrets become `secret://<env>/<bundle>/<pack>/<key>` URI refs (no plaintext).
- `validate_segment` rejects empty, `/`-bearing, `.`, `..`.
- `infer_bundle_id` derives a stable id from the bundle root.
- `try_emit_pack_config_input` derives FormSpec via `greentic_setup::setup_to_formspec::pack_to_form_spec` for the setup-input path where FormSpec isn't in the caller's hands.

## Wiring

- `persist_qa_secrets` now applies `qa_spec::resolve_visibility` so conditionally-invisible answers don't leak into either DevStore or the new file.
- `persist_qa_results` (QA wizard path) calls `emit_pack_config_input` after the secrets pass. Emit failures soft-fail with `tracing::warn!` — the C4.2 compat shim still serves these keys from DevStore.
- `persist_all_config_as_secrets` (setup-input / capability bootstrap / admin POST `/qa/apply`) calls `try_emit_pack_config_input` when `pack_path` is `Some` so non-QA paths also feed the channel.

The universal DevStore writes stay alive for one release as the C4.2 compatibility shim. A follow-up after PR4 lands and `pack_config_refs` is populated will drop the redundant non-secret DevStore writes.

## Tests

- `emit_pack_config_input_splits_secret_vs_non_secret` — split shape + no plaintext leak
- `emit_pack_config_input_secret_refs_discriminate_on_env_id` — env-segment integrity of `secret://`
- `emit_pack_config_input_skips_empty_config` — `Ok(None)` no-op
- `emit_pack_config_input_rejects_invalid_segments` — `/`, empty, `.`, `..`
- `emit_pack_config_input_respects_visibility` — `visible_if` parity with `persist_qa_secrets`
- `infer_bundle_id_uses_dir_name_with_bundle_fallback`

## Test plan

- [x] `cargo check --lib`
- [x] `cargo test --lib` (199 passed)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --lib --all-features -- -D warnings`
- [x] `bash ci/local_check.sh` — note: one parallelism flake in `secrets_gate::tests::env_selection_pack_uses_env_manager` reproduced once then passed on rerun; unrelated to this change.

Plan row: §6 C7 (PR3 — operator half). Pairs with `greentic-start` PR opened on the same branch name.