### PR TITLE
chore: relock greentic-bundle off yanked 1.2 -> 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,9 +2679,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-bundle"
-version = "1.2.0-dev.27526177406"
+version = "1.1.0-dev.27812212358"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69525de4b067fa582932fa78690bdadbb28cfc29bc6e3648c8f48393d5666f59"
+checksum = "5a61b433dc401a2ebd53b951147fe4f65d824ed5993ffaba041757a0769fce3a"
 dependencies = [
  "anyhow",
  "backhand",
@@ -2713,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-bundle-reader"
-version = "1.2.0-dev.27526177406"
+version = "1.1.0-dev.27812212358"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7f7e1e0ba3ad8f4fe54d1f38cdbdf7450670fbaab3d4dc5c26d281ae5bf4cf"
+checksum = "56044b2ba987803201b2ebe4e7a3540789b6e4d60e4ac3d78c411ea884a4109a"
 dependencies = [
  "backhand",
  "serde",
@@ -2778,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.27785617238"
+version = "1.1.0-dev.27818762095"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6a3b4116d91baaf6e283615aee18ed2302e7de4092cc4c4bff1f1ffe31fde4"
+checksum = "111fb3ebac21254644e12244a77c4c1d62ccb141d7bb53b39122de103b11dabf"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Why

The dev-lane `1.2 -> 1.1` revert (greenticai/greentic-bundle#131) yanked all `greentic-bundle 1.2.*` from crates.io. This repo's `Cargo.lock` still pinned the now-yanked `greentic-bundle@1.2.0-dev.27526177406`, pulled transitively via `greentic-deployer`. `--locked` builds kept working (yanked versions stay downloadable), but the pin is stale and a fresh resolve would fail.

## What

`cargo update -p greentic-deployer -p greentic-bundle -p greentic-bundle-reader`:

- `greentic-deployer -> 1.1.0-dev.27818762095` — the post-PR2 publish, whose `greentic-bundle` floor is `>=1.1.0-dev, <1.2.0-0`
- `greentic-bundle` + `greentic-bundle-reader` -> `1.1.0-dev.27812212358`

Deployer must move forward because its previously-locked version still floored `greentic-bundle >=1.2`, and every 1.2 is now yanked — so the bundle can only relock to 1.1 once deployer advances to the post-revert floor.

## Verification

- `cargo check` on the deployer-consuming crate — clean
- `cargo metadata --locked` — OK
