### PR TITLE
chore: start 1.2 pre-release lane (1.2.0-dev.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-ecs"
+version = "1.133.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7912c12ab87c23063e1f7cdecc9c195649a3895eb33669a216612e779ad0c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-elasticloadbalancingv2"
+version = "1.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9870778bd0e44ecce13520a473efa9f9d04804dfabb29ac056b8f44d39e5c9"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.2",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-iam"
 version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,12 +1090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,7 +1303,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1267,7 +1312,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1325,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "component-qa"
-version = "1.1.0-dev.27541005498"
+version = "1.2.0-dev.28928954940"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb947c0c27534a820fb69b3066b3528e6ad11f93147907798c33ee1b6bd97b6"
+checksum = "815366f25b9244ddb994cebfd72c005b7b3a263c082cc65a666a99831aef9a38"
 dependencies = [
  "greentic-interfaces-guest",
  "greentic-types",
@@ -1382,6 +1427,15 @@ name = "constant_time_eq"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a1ec0cfec728a79a5109075543131387f911cb4d07716436d7ae20533657a96"
+
+[[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1547,7 +1601,7 @@ dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
- "heck",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
@@ -1801,7 +1855,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn",
 ]
 
@@ -1815,7 +1869,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn",
 ]
 
@@ -1828,7 +1882,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn",
 ]
 
@@ -1919,7 +1973,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec2a42b511fc5efd9183f4f71c17885d627b17e7fd9a61a92089406caa4397e"
 dependencies = [
  "darling 0.21.3",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deluxe"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
+dependencies = [
+ "deluxe-core",
+ "deluxe-macros",
+ "once_cell",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "deluxe-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
+dependencies = [
+ "arrayvec",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "deluxe-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
+dependencies = [
+ "deluxe-core",
+ "heck 0.4.1",
+ "if_chain",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -2679,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-bundle"
-version = "1.1.0-dev.27812212358"
+version = "1.2.0-dev.28946580363"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a61b433dc401a2ebd53b951147fe4f65d824ed5993ffaba041757a0769fce3a"
+checksum = "3115670fe0f0c9e1e29a785df8792e53449e5e3a31f9b6201131d56daa0e2d78"
 dependencies = [
  "anyhow",
  "backhand",
@@ -2691,9 +2786,9 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "greentic-bundle-reader",
- "greentic-deploy-spec",
  "greentic-distributor-client",
  "greentic-qa-lib",
+ "greentic-secrets-spec",
  "hex",
  "rpassword",
  "semver",
@@ -2713,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-bundle-reader"
-version = "1.1.0-dev.27812212358"
+version = "1.2.0-dev.28946580363"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56044b2ba987803201b2ebe4e7a3540789b6e4d60e4ac3d78c411ea884a4109a"
+checksum = "31d032fc80a8043b442249686e8ec5b6ee6745492955c799166421075459c4d2"
 dependencies = [
  "backhand",
  "serde",
@@ -2724,9 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-config"
-version = "1.1.0-dev.27455469474"
+version = "1.2.0-dev.28926965123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391fd3376e4d5aa529a1531fef03c492944c62e42b9dfbc13fed8ec8b2efc18c"
+checksum = "fb17eba50fbde0049107f0782d4449b7394a4deee23cc68f2eaea933a5dfa2d4"
 dependencies = [
  "anyhow",
  "camino",
@@ -2744,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-config-types"
-version = "1.1.0-dev.27455469474"
+version = "1.2.0-dev.28926965123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eba492eaf9fd4a9ba4a1e50c0868b03791591eb9231cce1a32a8591f43e84dd"
+checksum = "a492561180044566a1b30f702ec98e1dee9556611bd80644eaa695dcf801d32f"
 dependencies = [
  "greentic-types",
  "serde",
@@ -2757,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.1.27909470946"
+version = "0.1.28955117012"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db982e86ee8e2f1937a90e311a3796fbb70c9aa68f0756e3ad52f6de46969143"
+checksum = "ef77bf4d47b41bec973799ebf030bfb42d2577f09d8de61bd99bd6034bad008e"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -2778,13 +2873,15 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.0-dev.28009791814"
+version = "1.2.0-dev.28955117012"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a21ec7b925e2513957b69e968494cd5121ba28ece425d17be13a412c25aaca"
+checksum = "f64460ed5a2befe4162f3c66f8cb4da2195d1dd4a8524cdd1c99b462c539c1b9"
 dependencies = [
  "anyhow",
  "async-trait",
  "aws-config",
+ "aws-sdk-ecs",
+ "aws-sdk-elasticloadbalancingv2",
  "aws-sdk-iam",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
@@ -2804,6 +2901,7 @@ dependencies = [
  "greentic-secrets-lib",
  "greentic-telemetry",
  "greentic-types",
+ "greentic-update",
  "hex",
  "indexmap 2.14.0",
  "jsonschema 0.46.5",
@@ -2838,9 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-distributor-client"
-version = "1.1.0-dev.27832309681"
+version = "1.2.0-dev.28940870391"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea23aae7a04e3adcf1bbf74adbf98f5fda29d3ba1c267216d2340b9ad85842b"
+checksum = "d995245103f383785ab1322342e2af5fce84e78da01ba1eefc39ecb1d0088e3d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2868,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-flow"
-version = "1.1.0-dev.27665160846"
+version = "1.2.0-dev.28947079750"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6410d9b52755749aac5355d454b84f15190b79ef9ee6449e13f5a9dd087d76"
+checksum = "a2218e401818aad265bf58d7043895f9d9136a3600182ac3d759ac74e2ed0820"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2911,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-i18n-translator"
-version = "1.1.0-dev.25901842811"
+version = "1.2.0-dev.28923702786"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea65ddac9ae71eb84df050276cd03b3dadcfb1261f9d562ad005dea0addef97"
+checksum = "9e907bce3e06676fd1a7f48906f0d460b71ea85dd45a4dd901231d5feae066fa"
 dependencies = [
  "blake3",
  "clap",
@@ -2923,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces"
-version = "1.1.0-dev.27127755811"
+version = "1.2.0-dev.28927057031"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c529dbde9ec0a596469ebce690a45d4dce6bf6089925cf23924bcbb01882369c"
+checksum = "ae316b3326e3574d6438bd32de5a3937ae379afa12a034654b222d636616f8f1"
 dependencies = [
  "anyhow",
  "constant_time_eq 0.4.2",
@@ -2941,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces-guest"
-version = "1.1.0-dev.27127755811"
+version = "1.2.0-dev.28927057031"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16575e48e4562c7e9b58a492450247e773bf0b6bee7614eb4537a52a30f292d2"
+checksum = "5549e777773a4469586bca0bad722c3240b3b796485b8aab44e65eb0d7957ab3"
 dependencies = [
  "greentic-interfaces",
  "greentic-types",
@@ -2954,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces-host"
-version = "1.1.0-dev.27127755811"
+version = "1.2.0-dev.28927057031"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4abc050f90f16281a3af1131ab297cb56c187734c9bf8c6ae83073c1b6d79a4"
+checksum = "dcf2a17a077dd07baacd8041f86bb1753e560d0c944930b7c2b9ea92c9a4c191"
 dependencies = [
  "greentic-interfaces",
  "greentic-types",
@@ -2967,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-interfaces-wasmtime"
-version = "1.1.0-dev.27127755811"
+version = "1.2.0-dev.28927057031"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c924cff3bad011bb2f3dfb0f2625160163bc45af42a9255ab6970a98e1caf6"
+checksum = "1104926ab0090c6e000b4494772cfad9eca0d461e7f4e161c0d7c267a767c0fa"
 dependencies = [
  "anyhow",
  "camino",
@@ -2983,9 +3081,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-llm"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6276d751b81024d12ec3962c0a82e91fd05627a0318e1bab5d25ddd97052d67"
+checksum = "6cc3e60cb52ccf7635ea7852e71ec912043a9ef5177db987a3dd11a436582890"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3000,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator-trust"
-version = "0.1.27909470946"
+version = "0.1.28955117012"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6d837d4aa8653c1e472590bedac8ae73b40353e5963708de4c1c1b84a1c6e3"
+checksum = "aa774f79133b7e44620afae1096cc02f84b6030df341092fc7bd06b678b2e459"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -3078,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-pack-lib"
-version = "1.1.0-dev.27667856463"
+version = "1.2.0-dev.28954197437"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23c41098d3cb15e85fb8290ec7ba501948a1f9f71306e817390d5bc8cad6deb"
+checksum = "1a39d628fd6917674774c9500497bbab43f9601d6d7079cd01d4a9c31c8b1615"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3111,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-qa-lib"
-version = "1.1.0-dev.27541005498"
+version = "1.2.0-dev.28928954940"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40d13d0e28a36e2ce36d33051ee73ff2d48e8d272256f6b7957e73ee9b8b92e"
+checksum = "08a2e69fe2930626a34f85ec7017d7c4d6685af177d00a30cb069d852ac9fd72"
 dependencies = [
  "component-qa",
  "qa-spec",
@@ -3125,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-desktop"
-version = "1.1.0-dev.27944159728"
+version = "1.2.0-dev.28965612811"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00db21859fcc49086962c8de86b385f1d22982a70f6db839872199a5f3c943aa"
+checksum = "aefc518584d00e8efc4e1c75ab2ae61d9951e511d10b297a4d8acd2e93890e77"
 dependencies = [
  "anyhow",
  "greentic-pack-lib",
@@ -3146,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-runner-host"
-version = "1.1.0-dev.27944159728"
+version = "1.2.0-dev.28965612811"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0464540ecff516f09e5cae658abf68d468786c6bd0fe39ed3de888dec7681be3"
+checksum = "db2767e0c6aceda9140a234f9c03d17ad4fb1048df650f1b1b7676ce1033138e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3183,7 +3281,7 @@ dependencies = [
  "jsonschema 0.45.1",
  "lru 0.16.4",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "parking_lot",
  "rand 0.10.1",
  "reqwest 0.13.4",
@@ -3213,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-api"
-version = "1.1.0-dev.27563392344"
+version = "1.2.0-dev.28929149875"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2848cc1a9794a635edebcfbdc6ab2b7eaceb0d98b258a6739785a2ca2e97d5"
+checksum = "cadcd2eb0122325b8d208f12d8c17fce88bb91fa177a35be11c6cc136dd8a4ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3224,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-core"
-version = "1.1.0-dev.27563392344"
+version = "1.2.0-dev.28929149875"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a6b34ace8be28106a3a42dc4dadd0e9188b65a96c269411e82ecb192b72c5f"
+checksum = "1980ece54595da79c7ce034475cf6673c7b3736fb7cacaf7e00528bcfb66a445"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3236,7 +3334,7 @@ dependencies = [
  "greentic-secrets-spec",
  "greentic-types",
  "hkdf",
- "lru 0.17.0",
+ "lru 0.18.0",
  "once_cell",
  "rand 0.10.1",
  "reqwest 0.13.4",
@@ -3252,23 +3350,24 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-lib"
-version = "1.1.0-dev.27563392344"
+version = "1.2.0-dev.28929149875"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3599872cae30a47ece2b9bffd43d143218dbed69d361638e43116942b317b8f"
+checksum = "8b1fdac9ad2fb38364fa5b7f8a619eaa970f92d6504afd8e7fd0456512904d7b"
 dependencies = [
  "async-trait",
  "greentic-secrets-api",
  "greentic-secrets-core",
  "greentic-secrets-provider-dev",
+ "greentic-secrets-provider-vault-kv",
  "greentic-secrets-spec",
  "greentic-types",
 ]
 
 [[package]]
 name = "greentic-secrets-provider-dev"
-version = "1.1.0-dev.27563392344"
+version = "1.2.0-dev.28929149875"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bf1b2a91eb59bc1f75cbe37e42f35dd1bcf9e6928073dc99f0e2bc1b55894"
+checksum = "c67fdbb87b7e9aa197bd24eb6b5476160fbd3d88c7fa2f1dd6743d5051e1f61b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3282,8 +3381,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "greentic-secrets-provider-vault-kv"
+version = "1.2.0-dev.28929149875"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a99d1429db6927be273f0323e8a2081f92de526c5f62e3a1160367d98e0744e"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "greentic-secrets-core",
+ "greentic-secrets-spec",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "greentic-secrets-repro"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 dependencies = [
  "anyhow",
  "greentic-secrets-lib",
@@ -3296,23 +3410,25 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-spec"
-version = "1.1.0-dev.27563392344"
+version = "1.2.0-dev.28929149875"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae86ba4652dbb965b11ec54d2ec6cba73836dad0182aa49d542eeeac4f4ecb69"
+checksum = "6368327b75fc0cb81979ff2ec24c8d4e348badc9748aaf36a2f787f7e0e1f4df"
 dependencies = [
  "async-trait",
  "greentic-types",
+ "hex",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
 name = "greentic-session"
-version = "1.1.0-dev.27455500542"
+version = "1.2.0-dev.28928960090"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aa33926157d5315693adc6b10c78eed4dcd57db5ee151b10a7ff87127e1424"
+checksum = "d7224dee7bbdc059525dc0ffc0561a13c422c4165951dc24d3e53a9a11a37f18"
 dependencies = [
  "greentic-types",
  "hex",
@@ -3324,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-setup"
-version = "1.1.0-dev.27946905361"
+version = "1.2.0-dev.28970794962"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5f7001c8d3c04bfcca84911c845ef36cd1f51bfba2eb91f0decb4d8efa3ff6"
+checksum = "59815c6d6270abe2f3ff5b1c9a775c6b77bd134448213b1d4766524edaa524a8"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -3336,6 +3452,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "dialoguer",
+ "flate2",
  "greentic-deployer",
  "greentic-distributor-client",
  "greentic-runner-host",
@@ -3346,6 +3463,7 @@ dependencies = [
  "qa-spec",
  "rand 0.10.1",
  "regex",
+ "reqwest 0.13.4",
  "rpassword",
  "serde",
  "serde_cbor",
@@ -3362,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-start"
-version = "1.1.0-dev.27978051609"
+version = "1.2.0-dev.28977335540"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69381813281ba0851eac990c9dc183067964b04c7eaeff46addb13bd397ca32c"
+checksum = "3a4304170c3b957ec340b8c70b0599c0592dcce9e7a47a164bcb867f4a156567"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3397,10 +3515,10 @@ dependencies = [
  "notify-debouncer-full",
  "once_cell",
  "open",
- "opentelemetry",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry-appender-tracing 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "qa-spec",
  "rand 0.10.1",
  "redis",
@@ -3425,7 +3543,7 @@ dependencies = [
  "tokio-tungstenite 0.29.0",
  "tracing",
  "tracing-appender",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
  "ulid",
  "unic-langid",
@@ -3439,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-state"
-version = "1.1.0-dev.27455503102"
+version = "1.2.0-dev.28928964650"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a2267094b2956e70c78f65988c5ae4271c7266e819a37bd08057fdd349ec7d"
+checksum = "4ffa87ffeaad41c20a84a5c577886813bbfcc9bad2b5b464d0393e15fbfd09df"
 dependencies = [
  "dashmap",
  "greentic-interfaces",
@@ -3458,31 +3576,31 @@ dependencies = [
 
 [[package]]
 name = "greentic-telemetry"
-version = "1.1.0-dev.27365608653"
+version = "1.2.0-dev.28923800659"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d00677e506e4fead6b4837ca6e1e65669dae8e2ffad400d93a59eed3ffcc63"
+checksum = "1682057ab426d79ca7294fa820492c28879232f2365d2b52b74d765c45f2f672"
 dependencies = [
  "anyhow",
  "once_cell",
- "opentelemetry",
- "opentelemetry-appender-tracing",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry-appender-tracing 0.31.1",
+ "opentelemetry-otlp 0.31.1",
+ "opentelemetry_sdk 0.31.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-error",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.1",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "greentic-types"
-version = "1.1.0-dev.27943617354"
+version = "1.2.0-dev.28924494708"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc24dd49f377510d3c2503717c05788cdd5c71e6f14db635f4eacc1c190f386"
+checksum = "1097d4d60cc94b3904caf7eb26f43f7c1c824a35cbbb7719c9c7c0472e501969"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3493,7 +3611,7 @@ dependencies = [
  "greentic-telemetry",
  "greentic-types-macros",
  "indexmap 2.14.0",
- "opentelemetry-otlp",
+ "opentelemetry-otlp 0.31.1",
  "schemars 1.2.1",
  "semver",
  "serde",
@@ -3511,13 +3629,34 @@ dependencies = [
 
 [[package]]
 name = "greentic-types-macros"
-version = "1.1.0-dev.27943617354"
+version = "1.2.0-dev.28924494708"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12df693f737b82f4085d979533b900050bf4226ea9879d739ecf5e2b2190fd6"
+checksum = "f7d399561efec1a6e8465f12f382ea9d5c8a0ef8a5200002dece59d34f1c56c9"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "greentic-update"
+version = "0.1.28946597636"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d9de3f1a6fe1fd7be064fea8c71fee7b1d90099880bf942dde6e80666d4303a"
+dependencies = [
+ "chrono",
+ "fs4",
+ "greentic-distributor-client",
+ "hex",
+ "rcgen",
+ "reqwest 0.13.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "x509-parser",
 ]
 
 [[package]]
@@ -3638,6 +3777,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -4008,6 +4153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+
+[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,6 +4198,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -4554,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0b564323a0fb6d54b864f625ae139de9612e27edb944dda37c109f05aac531"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5047,12 +5207,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -5067,8 +5253,20 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.2",
+ "opentelemetry 0.32.0",
 ]
 
 [[package]]
@@ -5078,10 +5276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.2",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry-http 0.31.0",
+ "opentelemetry-proto 0.31.0",
+ "opentelemetry_sdk 0.31.0",
  "prost",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
@@ -5091,13 +5289,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.2",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
+ "opentelemetry-proto 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "prost",
  "tonic",
  "tonic-prost",
@@ -5112,8 +5341,26 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -5465,11 +5712,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -5505,6 +5762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5529,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "qa-spec"
-version = "1.1.0-dev.27541005498"
+version = "1.2.0-dev.28928954940"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6625d11fd15089c7a480dee71ec03ecaf8b54858cda21376b241c3c8528775e"
+checksum = "86d533609aeb21d9f42c9c7f6ab7c8ac477ff18692ace6ca936d718d10bcca9e"
 dependencies = [
  "globset",
  "handlebars",
@@ -5755,12 +6021,16 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
  "ryu",
  "sha1_smol",
  "socket2",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "url",
+ "webpki-roots 1.0.8",
  "xxhash-rust",
 ]
 
@@ -5996,9 +6266,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac7d75266ac1f79b1faeff611c85cb40be00a0a983db10036591424f0433dc1"
+checksum = "557f11c26c2c2ea61d9cb843ce5adff138cc5785f58ff4b87d779de8acaa32ae"
 dependencies = [
  "as-any",
  "async-stream",
@@ -6016,15 +6286,32 @@ dependencies = [
  "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest 0.13.4",
+ "rig-derive",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "tracing-futures",
  "url",
+]
+
+[[package]]
+name = "rig-derive"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643eb495acbd4bd5976164cd068f186d534f741def8d5d052f860266b98d07f8"
+dependencies = [
+ "convert_case",
+ "deluxe",
+ "indoc",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -6064,9 +6351,9 @@ dependencies = [
 
 [[package]]
 name = "runner-core"
-version = "1.1.0-dev.27823510319"
+version = "1.2.0-dev.28965612811"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7779ea9b9ba6369391872947fe0403b21c06d6fc278f8af4db1886411b44b76"
+checksum = "eab4b48c6e4a26bd8cd71561375bffa00ef4b17a6e91c8fcb1db513886550af6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6331,7 +6618,7 @@ dependencies = [
 
 [[package]]
 name = "secret_name"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 
 [[package]]
 name = "security-framework"
@@ -6718,6 +7005,12 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -7026,9 +7319,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -7036,7 +7329,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.23.0",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -7097,6 +7390,12 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
@@ -7111,6 +7410,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -7174,6 +7484,17 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
  "tonic",
 ]
 
@@ -7315,7 +7636,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -7363,21 +7700,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.4.2",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -7470,6 +7806,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -7722,7 +8064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "log",
  "petgraph",
@@ -8112,7 +8454,7 @@ checksum = "4ae00896ad9bef1b3ca6401ae9a841daa6f357dd91541b6baf87082946d1bde1"
 dependencies = [
  "anyhow",
  "bitflags",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "wit-parser 0.248.0",
 ]
@@ -8297,7 +8639,7 @@ version = "45.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604976b16d40f15606ae47ca22473c7574b317a6445ea2e3986f834a2ca0f449"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -8655,6 +8997,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -8697,7 +9048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dee27a2dc20d1008016c742ec9fc6ea498492994ba3750be7454cbc97ff04c"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser 0.247.0",
 ]
 
@@ -8708,7 +9059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ bin = [
 
 [package]
 name = "greentic-operator"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic operator CLI for local dev and demo orchestration."
@@ -44,18 +44,18 @@ directories-next = "2"
 # Floor 0.1.26948183687: ExtensionBinding / ExtensionRef (Path 3 capability slot).
 greentic-deploy-spec = ">=0.1.26948183687, <0.2"
 # Floor 1.1.0-dev.26948183687: `op extensions` noun (compiled into this CLI via OpCommand).
-greentic-deployer = ">=1.1.0-dev, <1.2.0-0"
-greentic-setup = ">=1.1.0-dev, <1.2.0-0"
-greentic-qa-lib = ">=1.1.0-dev, <1.2.0-0"
-greentic-start = ">=1.1.0-dev, <1.2.0-0"
-greentic-state = ">=1.1.0-dev, <1.2.0-0"
+greentic-deployer = ">=1.2.0-dev, <1.3.0-0"
+greentic-setup = ">=1.2.0-dev, <1.3.0-0"
+greentic-qa-lib = ">=1.2.0-dev, <1.3.0-0"
+greentic-start = ">=1.2.0-dev, <1.3.0-0"
+greentic-state = ">=1.2.0-dev, <1.3.0-0"
 http-body-util = "0.1"
 hyper-util = "0.1"
 include_dir = "0.7"
 jsonschema = "0.45"
 libc = "0.2"
 once_cell = "1.21"
-qa-spec = ">=1.1.0-0, <1.2.0-0"
+qa-spec = ">=1.2.0-dev, <1.3.0-0"
 rand = "0.10"
 rpassword = "7"
 semver = "1"
@@ -77,45 +77,45 @@ features = [
 ]
 
 [dependencies.greentic-distributor-client]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 default-features = false
 features = [
     "pack-fetch",
 ]
 
 [dependencies.greentic-interfaces]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-interfaces-guest]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-interfaces-host]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-interfaces-wasmtime]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-runner-desktop]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-runner-host]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-secrets-lib]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "providers-dev",
 ]
 
 [dependencies.greentic-telemetry]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "otlp",
     "fmt",
 ]
 
 [dependencies.greentic-types]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "serde",
 ]
@@ -190,7 +190,7 @@ features = [
 ]
 
 [workspace.dependencies.greentic-secrets-lib]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "providers-dev",
 ]

--- a/crates/greentic-secrets-repro/Cargo.toml
+++ b/crates/greentic-secrets-repro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "greentic-secrets-repro"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 edition = "2021"
 description = "Minimal repro crate for greentic dev secrets roundtrips."
 license = "MIT"

--- a/secret_name/Cargo.toml
+++ b/secret_name/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret_name"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 edition = "2021"
 description = "Shared helpers for canonicalizing Greentic secret names."
 license = "MIT"

--- a/src/deployments/api.rs
+++ b/src/deployments/api.rs
@@ -570,12 +570,10 @@ mod tests {
     #[tokio::test]
     async fn end_to_end_through_deployer_lib_returns_typed_error_envelope() {
         // Drives a full happy-path payload through `dispatch` → deployer
-        // library → `op_error_response`. The deployer's `audit_and_record`
-        // wrapper runs `authorize_local_only` first, which denies inside the
-        // sandboxed test environment (no local-actor signal), so we expect a
-        // 403 with the documented envelope. The point of the test is the
-        // round-trip: handler invoked the lib, got a typed `OpError`, mapped
-        // it to the right HTTP status, and serialized the documented body.
+        // library → `op_error_response`. The deployer returns a typed
+        // `OpError` (the empty temp dir has no environment, so `NotFound`
+        // fires before any auth check) and the handler maps it to the
+        // right HTTP status and serializes the documented body.
         // ULIDs are Crockford Base32 (no I/L/O/U); use a real one so we
         // get past the ID-parse branch.
         let tmp = tempfile::tempdir().unwrap();
@@ -587,10 +585,10 @@ mod tests {
         }"#;
         let err = dispatch(Method::POST, "/deployments/stage", body, &state)
             .await
-            .expect_err("local-only auth denial must surface");
-        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+            .expect_err("deployer must surface an error for missing env");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
         let body = read_body_json(*err).await;
-        assert_eq!(body["error"]["kind"], "unauthorized");
+        assert_eq!(body["error"]["kind"], "not-found");
     }
 
     #[test]

--- a/tests/demo_events_up.rs
+++ b/tests/demo_events_up.rs
@@ -74,6 +74,7 @@ fn simple_flow(flow_id: &str) -> anyhow::Result<Flow> {
             err_map: None,
             routing: Routing::End,
             telemetry: TelemetryHints::default(),
+            conversational: false,
         },
     );
     let mut entrypoints = std::collections::BTreeMap::new();

--- a/tests/demo_list_commands.rs
+++ b/tests/demo_list_commands.rs
@@ -95,6 +95,7 @@ fn simple_flow(flow_id: &str) -> anyhow::Result<Flow> {
             err_map: None,
             routing: Routing::End,
             telemetry: TelemetryHints::default(),
+            conversational: false,
         },
     );
     let mut entrypoints = BTreeMap::new();

--- a/tests/demo_runner.rs
+++ b/tests/demo_runner.rs
@@ -91,6 +91,7 @@ fn blocking_pack_manifest(pack_id: &str) -> Result<PackManifest> {
                 node_id: NodeId::new("final").unwrap(),
             },
             telemetry: TelemetryHints::default(),
+            conversational: false,
         },
     );
     nodes.insert(
@@ -111,6 +112,7 @@ fn blocking_pack_manifest(pack_id: &str) -> Result<PackManifest> {
             err_map: None,
             routing: Routing::End,
             telemetry: TelemetryHints::default(),
+            conversational: false,
         },
     );
 

--- a/tests/demo_setup_all_providers.rs
+++ b/tests/demo_setup_all_providers.rs
@@ -74,6 +74,7 @@ fn simple_flow(flow_id: &str) -> anyhow::Result<Flow> {
             err_map: None,
             routing: Routing::End,
             telemetry: TelemetryHints::default(),
+            conversational: false,
         },
     );
     let mut entrypoints = BTreeMap::new();

--- a/vendor/patches/greentic-start/Cargo.toml
+++ b/vendor/patches/greentic-start/Cargo.toml
@@ -6,7 +6,7 @@ bin = [
 edition = "2024"
 rust-version = "1.91"
 name = "greentic-start"
-version = "1.1.1-dev.0"
+version = "1.2.0-dev.0"
 build = false
 autolib = false
 autobins = false
@@ -61,29 +61,29 @@ features = [
 ]
 
 [dependencies.greentic-distributor-client]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "pack-fetch",
 ]
 default-features = false
 
 [dependencies.greentic-setup]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-runner-desktop]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-runner-host]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.greentic-secrets-lib]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "providers-dev",
 ]
 
 [dependencies.greentic-types]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 features = [
     "serde",
 ]
@@ -113,7 +113,7 @@ version = "0.2"
 version = "1.21"
 
 [dependencies.qa-spec]
-version = ">=1.1.0-0, <1.2.0-0"
+version = ">=1.2.0-dev, <1.3.0-0"
 
 [dependencies.rand]
 version = "0.10"


### PR DESCRIPTION
## Summary

Wave W9b of the fleet-wide develop-lane minor bump: **1.1 -> 1.2**.

- **Version bump**: `1.1.1-dev.0` -> `1.2.0-dev.0` (root + 3 sub-crates)
- **Dep-range rewrite**: all greentic ecosystem deps moved from `">=1.1.0-0, <1.2.0-0"` / `">=1.1.0-dev, <1.2.0-0"` to `">=1.2.0-dev, <1.3.0-0"`
- **Lockfile**: refreshed with `cargo update -w` (workspace members only); no research-lane versions; `greentic-llm` updated `1.0.1 -> 1.1.0` to fix greentic-start 1.2 compilation

Cargo's pre-release firewall means consumers on `^1.1` are completely unaffected until they explicitly opt in to the 1.2 range.

## Extra fixes

1. **Node `conversational` field** (greentic-types 1.2 breaking change): added `conversational: false` to all 5 `Node { .. }` struct literals across 4 test files (`demo_events_up.rs`, `demo_list_commands.rs`, `demo_runner.rs`, `demo_setup_all_providers.rs`).

2. **Deployer error-path change** (greentic-deployer 1.2): updated `end_to_end_through_deployer_lib_returns_typed_error_envelope` test -- deployer 1.2 returns `NotFound` (404) for the empty-env temp dir before reaching the auth check that 1.1 reached first (`Unauthorized`/403).

3. **greentic-llm lockfile pin**: updated from `1.0.1` to `1.1.0` -- `greentic-start 1.2.0-dev` references `ChatMessage`/`Credential` fields that were added in `greentic-llm 1.1.0`.

## Local gate

- `cargo fmt --check`: PASS
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: PASS
- `cargo test --workspace --all-features`: PASS (201+ tests, 0 failures)
