### PR TITLE
chore: raise greentic-deployer floor to 1.1.11, bump operator to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a381c8c7a7b3c1e4ef80b31632ccc518a6017b86a756b55cccef967b91a732"
+checksum = "c223b915ebc5076fef65e131fbbfd2634cbcf12770287d5e23c634a5c6dae501"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ bin = [
 
 [package]
 name = "greentic-operator"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic operator CLI for local dev and demo orchestration."
@@ -48,11 +48,11 @@ directories-next = "2"
 # so a `>=0.2.0` floor here lets a resolve pick 0.2.0 and the *deployer* fails to build.
 # Tracked upstream as greenticai/greentic-deployer#444.
 greentic-deploy-spec = ">=0.2.2, <0.3"
-# Floor 1.1.10: `UpdatesVerb::Publish` — this CLI compiles the deployer's whole `OpCommand`
-# clap tree (`Command::Op` → `dispatch_op`), so `op updates publish` exists here only if the
-# deployer exports it. Absent in 1.1.9. The `-0` suffix is deliberately gone from every floor
+# Floor 1.1.11: `EnvVerb::Up` — this CLI compiles the deployer's whole `OpCommand`
+# clap tree (`Command::Op` → `dispatch_op`), so `op env up` exists here only if the
+# deployer exports it. Absent in 1.1.10. The `-0` suffix is deliberately gone from every floor
 # in this file: a main-branch binary must never resolve a develop-lane pre-release.
-greentic-deployer = ">=1.1.10, <1.2.0-0"
+greentic-deployer = ">=1.1.11, <1.2.0-0"
 greentic-setup = ">=1.1.0, <1.2.0-0"
 greentic-qa-lib = ">=1.1.0, <1.2.0-0"
 # Floor 1.1.10, not 1.1.9: every publish below it pins `async-nats = "0.46"`, which


### PR DESCRIPTION
Third and final code PR of **Release 1** of the one-command K8s deployment work, after
greentic-deployer#446 (`op env up`, 1.1.11) and greentic#248 (`gtc start k8s`, 1.1.4) — both merged.

## Why a republish is required, not just a floor bump

`greentic-operator` compiles the deployer's entire `OpCommand` clap tree:

```rust
// src/cli.rs:87
Op(Box<greentic_deployer::cli::dispatch::OpCommand>),
```

There is no verb enumeration anywhere in this repo, so `op env up` arrives for free with the
dependency — but only in a binary *built against* deployer 1.1.11. Until this ships as
`greentic-operator 1.1.2`, `gtc start k8s` (which rewrites to `op env up` and spawns
`greentic-operator`) dies on a clap "unrecognized subcommand".

## Diff

Four lines, no transitive churn — `#446` changed no dependencies, only the deployer's own version.

| File | Change |
|---|---|
| `Cargo.toml` | `version` 1.1.1 → 1.1.2 |
| `Cargo.toml` | `greentic-deployer` floor `>=1.1.10` → `>=1.1.11`, comment restated for `EnvVerb::Up` |
| `Cargo.lock` | `greentic-deployer` 1.1.10 → 1.1.11 (+ checksum), `greentic-operator` 1.1.1 → 1.1.2 |

The lock is refreshed **in this commit**: a `--locked` consumer resolving the stale lock would still
pin deployer 1.1.10 and silently lose the verb.

## Verification (run locally against the published 1.1.11)

- `cargo build --locked --bin greentic-operator`, then `greentic-operator op env --help` — `up` is
  listed, with the phase description from `#446`.
- `bash ci/local_check.sh` → **exit 0** (fmt, i18n quality, `clippy --locked -D warnings`,
  `test --locked`, binstall packaging).
- `cargo publish --dry-run -p greentic-operator` → **exit 0**, resolving `greentic-deployer v1.1.11`.

### Note: `local_check.sh` never runs its own publish dry-run in this repo

Lines 21–28 skip the dry-run when any `Cargo.toml` matches `path\s*=`. This repo's manifest opens with

```toml
bin = [
    { name = "greentic-operator", path = "src/main.rs" },
]
```

so the grep always matches and the check always prints `path dependencies present; skipping publish
dry-run`. I ran the dry-run by hand instead (above). Not fixed here — it is pre-existing and out of
scope for a version bump — but worth a follow-up: the guard means a stray real path dep would not be
caught either.

## Follow-up, not in this PR

`gtc install` resolves binaries from pinned versions in the OCI toolchain manifest
(`ghcr.io/greenticai/greentic-versions/gtc:stable`), which currently pins `greentic-operator 1.1.1` and
`greentic-deployer 1.1.10`. Once 1.1.2 publishes, that manifest needs refreshing in `greentic-dev`
(`dist/toolchains/gtc-1.1.2.json`) or an installed `gtc` will keep shipping an operator without
`op env up`.

Refs greenticai/greentic-deployer#446, greenticai/greentic#248.
