### PR TITLE
chore(deps): embed greentic-deployer 1.1.16 (Vault flow), operator 1.1.4 (R2-4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1321,7 +1321,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -2390,7 +2390,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2561,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3158,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33844530b686aac0b28dd2a4470a028b50d00fa51ee60dd26b6c9e81507b7dc3"
+checksum = "edf0d6b72d929d29cfa02ecbc0c1aed2b614d89a455dcd795f126005619dc177"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -3179,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.11"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223b915ebc5076fef65e131fbbfd2634cbcf12770287d5e23c634a5c6dae501"
+checksum = "26cb051f40755cfa382bd6ee3e81b5239e4117544ecce25efb0eaf0d27b19eb3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3201,7 +3201,7 @@ dependencies = [
  "greentic-bundle",
  "greentic-config",
  "greentic-config-types",
- "greentic-deploy-spec 0.2.2",
+ "greentic-deploy-spec 0.2.3",
  "greentic-distributor-client",
  "greentic-operator-trust",
  "greentic-secrets-lib",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3538,7 +3538,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories-next",
- "greentic-deploy-spec 0.2.2",
+ "greentic-deploy-spec 0.2.3",
  "greentic-deployer",
  "greentic-distributor-client",
  "greentic-interfaces",
@@ -3592,7 +3592,7 @@ checksum = "a031e3571c44d2aa0e1ee91c1bc18dc6393140aabfea9f73d53637cffb68d717"
 dependencies = [
  "chrono",
  "ed25519-dalek",
- "greentic-deploy-spec 0.2.2",
+ "greentic-deploy-spec 0.2.3",
  "greentic-distributor-client",
  "hex",
  "libc",
@@ -3694,7 +3694,7 @@ dependencies = [
  "greentic-aw-runtime",
  "greentic-config",
  "greentic-config-types",
- "greentic-deploy-spec 0.2.2",
+ "greentic-deploy-spec 0.2.3",
  "greentic-distributor-client",
  "greentic-ext-runtime",
  "greentic-flow",
@@ -3786,9 +3786,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-lib"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b73a688736c3179588e1cb68823aeb8a8a5441de1316389b06aa0040bd0922"
+checksum = "c05df8380254d892a227519239202f673d624cc166564d93f9371d3502183857"
 dependencies = [
  "async-trait",
  "greentic-secrets-api",
@@ -3818,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-secrets-provider-vault-kv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac85e6de7e9a6b967a820cb4d197671f7ec69ca22d59013d958c4c25c985287c"
+checksum = "1c11c30ccba3bb89699f6a7b1893e5545ab0fe539332e5856f311b9255b6f184"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4004,18 +4004,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47eb7b004ef9ad38b5d11acd9561c4b0cf28f9126c9cfe1d86fcf8ae66c6691"
 dependencies = [
  "chrono",
+ "flate2",
  "fs4",
  "greentic-distributor-client",
  "hex",
  "rcgen",
  "reqwest 0.13.4",
+ "self-replace",
  "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "x509-parser",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5369,7 +5373,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6189,7 +6193,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6733,7 +6737,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6802,7 +6806,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6961,6 +6965,17 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7336,7 +7351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7701,7 +7716,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9145,7 +9160,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ bin = [
 
 [package]
 name = "greentic-operator"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic operator CLI for local dev and demo orchestration."
@@ -47,12 +47,11 @@ directories-next = "2"
 # `UpdateAction` / `resolved_action()` (deploy-spec 0.2.2) while declaring only `"0.2"`,
 # so a `>=0.2.0` floor here lets a resolve pick 0.2.0 and the *deployer* fails to build.
 # Tracked upstream as greenticai/greentic-deployer#444.
-greentic-deploy-spec = ">=0.2.2, <0.3"
-# Floor 1.1.11: `EnvVerb::Up` — this CLI compiles the deployer's whole `OpCommand`
-# clap tree (`Command::Op` → `dispatch_op`), so `op env up` exists here only if the
-# deployer exports it. Absent in 1.1.10. The `-0` suffix is deliberately gone from every floor
-# in this file: a main-branch binary must never resolve a develop-lane pre-release.
-greentic-deployer = ">=1.1.11, <1.2.0-0"
+greentic-deploy-spec = ">=0.2.3, <0.3"
+# Floor 1.1.16: embeds Vault flow (R2-2, 1.1.12), pack-list repair (1.1.14), and
+# provider-pack pin fix (1.1.15). The `-0` suffix is deliberately gone from every
+# floor in this file: a main-branch binary must never resolve a develop-lane pre-release.
+greentic-deployer = ">=1.1.16, <1.2.0-0"
 greentic-setup = ">=1.1.0, <1.2.0-0"
 greentic-qa-lib = ">=1.1.0, <1.2.0-0"
 greentic-state = ">=1.1.0, <1.2.0-0"
@@ -116,7 +115,7 @@ version = ">=1.1.0, <1.2.0-0"
 version = ">=1.1.6, <1.2.0-0"
 
 [dependencies.greentic-secrets-lib]
-version = ">=1.1.0, <1.2.0-0"
+version = ">=1.1.5, <1.2.0-0"
 features = [
     "providers-dev",
 ]
@@ -204,7 +203,7 @@ features = [
 ]
 
 [workspace.dependencies.greentic-secrets-lib]
-version = ">=1.1.0, <1.2.0-0"
+version = ">=1.1.5, <1.2.0-0"
 features = [
     "providers-dev",
 ]


### PR DESCRIPTION
## R2-4 — embed greentic-deployer 1.1.16 (operator 1.1.4)

**The release unblocker.** Until now greentic-operator (1.1.3) statically linked
greentic-deployer **1.1.11**, so `gtc op env up` / `gtc start k8s` ran a deployer
with **no Vault flow** (R2-2) and **without** the provider-pack pin fix (1.1.15) or
pack-list repair (1.1.14). This bump makes the embedded deployer **1.1.16** — finally
making the one-command K8s + Vault path reachable through `gtc`.

### Not a clean floor bump — two underspecified upstream floors
- **deployer 1.1.16** declares `greentic-secrets-lib >=1.1.0` but its code calls
  `build_backend_with` (secrets-lib **1.1.5**). So the operator's own secrets-lib
  floor is raised to `>=1.1.5` in **both** `[dependencies]` and
  `[workspace.dependencies]` — else a fresh resolve keeps 1.1.4 and the embedded
  deployer fails to compile.
- **secrets-lib 1.1.5** in turn declares `greentic-secrets-provider-vault-kv
  >=1.1.1-0` but needs 1.1.5; the lockfile pins vault-kv 1.1.5 to compensate.

(Both are latent upstream floor-hygiene bugs — worth a follow-up in their own repos;
neither blocks this PR, which fixes the resolution operator-side.)

### Changes
| Floor | Before | After |
|---|---|---|
| `greentic-deployer` | `>=1.1.11` | `>=1.1.16` |
| `greentic-deploy-spec` | `>=0.2.2` | `>=0.2.3` (defensive) |
| `greentic-secrets-lib` (×2 blocks) | `>=1.1.0` | `>=1.1.5` |
| package version | 1.1.3 | **1.1.4** |

Cargo.lock relocked: deployer 1.1.16, secrets-lib 1.1.5, vault-kv 1.1.5, deploy-spec
0.2.3 (single boundary copy; its stale 0.1.x transitive copy is pre-existing and
untouched). No collateral floor changes — telemetry / state / qa-lib / runner-host /
setup all untouched.

### Verification
`bash ci/local_check.sh` → green: `cargo build --release`, `clippy -D warnings`, and
all unit tests pass against the **crates.io-resolved** deployer 1.1.16 / secrets-lib
1.1.5 / vault-kv 1.1.5 tree. Single-copy resolution of each shared crate confirmed; no
`-dev` / pre-release strings in any floor or the package version.

> Note: operator `local_check` skips `cargo publish --dry-run` (a pre-existing
> false-positive matching the `[[bin]] path = "src/main.rs"` line), so the crates.io
> publish is first exercised at release time — as with every prior operator release
> (1.1.3 included).

Part of `plans/one-command-k8s-deployment.md` Release 2. On merge + publish (~20 min),
the toolchain repoint (gtc manifest → operator 1.1.4) and the native demo follow.
