### PR TITLE
release: greentic-operator 1.1.5 — deploy-spec =0.2.6, deployer >=1.1.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deploy-spec"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9201a90bc9f590a95b50409dc42eff039f98ebe1ff8f9ebe8c7a10508b8570b2"
+checksum = "809e75ae297c59253308f25789c23aebd3c5adab3d7ec5ae0f98cabb99173b8b"
 dependencies = [
  "chrono",
  "greentic-config-types",
@@ -3188,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "greentic-deployer"
-version = "1.1.29"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4423922af13da898524f1b9d9452a8783c4c680d3751cb46459ee74fc08f751"
+checksum = "693deced55062c8f01e1db7864e7ca8872b36b5160c4e656a17767d7b761652c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3210,7 +3210,7 @@ dependencies = [
  "greentic-bundle",
  "greentic-config",
  "greentic-config-types",
- "greentic-deploy-spec 0.2.5",
+ "greentic-deploy-spec 0.2.6",
  "greentic-distributor-client",
  "greentic-operator-trust",
  "greentic-secrets-lib",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "greentic-operator"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3548,7 +3548,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories-next",
- "greentic-deploy-spec 0.2.5",
+ "greentic-deploy-spec 0.2.6",
  "greentic-deployer",
  "greentic-distributor-client",
  "greentic-interfaces",
@@ -3602,7 +3602,7 @@ checksum = "a031e3571c44d2aa0e1ee91c1bc18dc6393140aabfea9f73d53637cffb68d717"
 dependencies = [
  "chrono",
  "ed25519-dalek",
- "greentic-deploy-spec 0.2.5",
+ "greentic-deploy-spec 0.2.6",
  "greentic-distributor-client",
  "hex",
  "libc",
@@ -3704,7 +3704,7 @@ dependencies = [
  "greentic-aw-runtime",
  "greentic-config",
  "greentic-config-types",
- "greentic-deploy-spec 0.2.5",
+ "greentic-deploy-spec 0.2.6",
  "greentic-distributor-client",
  "greentic-ext-runtime",
  "greentic-flow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ bin = [
 
 [package]
 name = "greentic-operator"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2024"
 rust-version = "1.95"
 description = "Greentic operator CLI for local dev and demo orchestration."
@@ -49,9 +49,19 @@ directories-next = "2"
 # Tracked upstream as greenticai/greentic-deployer#444.
 # Exact pin: a `<0.3` upper bound admits dev-lane `0.2.<RUN_ID>` publishes (e.g.
 # 0.2.29986812583), which drag in `greentic-types >=1.2.0-dev` and conflict with
-# this crate's stable types pin. An exact `=0.2.5` is the only form that excludes
+# this crate's stable types pin. An exact pin is the only form that excludes
 # those run-id versions while keeping both this crate and deployer on the same copy.
-greentic-deploy-spec = "=0.2.5"
+# crates.io's `max_stable_version` for this crate currently REPORTS a run-id build
+# (0.2.30193933262), so read the version list, never max_stable, when raising it.
+# 0.2.6, not 0.2.5: 0.2.6 adds `UpdateHostConfig::default_bundle`
+# (`FieldUpdate<BundleId>`) and its `apply_to`, which is the settable half of
+# greentic-deployer#521. The pin is what actually gates it — with `=0.2.5` here,
+# the `>=1.1.29` deployer range below resolves to 1.1.29 (1.1.30 requires
+# `=0.2.6`), so `op env apply` shipped an env-manifest parser with no
+# `default_bundle` field and hard-failed `answers-parse: unknown field
+# 'default_bundle'` on any manifest that used it. `gtc op` routes here, so that
+# was the whole `gtc` porcelain, not just this binary.
+greentic-deploy-spec = "=0.2.6"
 # Floor 1.1.29: embeds Vault flow (R2-2, 1.1.12), pack-list repair (1.1.14), and
 # provider-pack pin fix (1.1.15). Raised from 1.1.16 because deploy-spec
 # 0.2.5 makes `EnvironmentHostConfig` `#[non_exhaustive]`: every deployer below
@@ -60,9 +70,13 @@ greentic-deploy-spec = "=0.2.5"
 # floors move together — deploy-spec >=0.2.5 requires deployer >=1.1.29.
 # 1.1.29, not 1.1.28: main cut and published 1.1.28 from greentic-deployer#520
 # while this work was open, so that release still carries the literals.
+# Raised to 1.1.30 together with the deploy-spec pin above — the two floors move
+# as a pair, and 1.1.30 is the first publish that declares `=0.2.6`. It is also
+# the release that carries `ManifestEnvironment::default_bundle`, so this floor is
+# an API floor for `op env apply`, not housekeeping.
 # The `-0` suffix is deliberately gone from every floor in this file: a
 # main-branch binary must never resolve a develop-lane pre-release.
-greentic-deployer = ">=1.1.29, <1.2.0-0"
+greentic-deployer = ">=1.1.30, <1.2.0-0"
 greentic-setup = ">=1.1.0, <1.2.0-0"
 greentic-qa-lib = ">=1.1.0, <1.2.0-0"
 greentic-state = ">=1.1.0, <1.2.0-0"


### PR DESCRIPTION
`gtc op env apply` cannot read an env-manifest that names `default_bundle`:

```
{"op":"apply","noun":"env","error":{"kind":"answers-parse","message":
 "invalid json/yaml in env-manifest.json: json: unknown field `default_bundle`,
  expected one of `id`, `public_base_url`, `name`, `region`, `tenant_org_id`,
  `listen_addr`, `gui_enabled` at line 7 column 20"}}
```

## The pin was the bug, not the version

`greentic-deployer` 1.1.30 declares `greentic-deploy-spec = "=0.2.6"`. With `=0.2.5` pinned here, the `>=1.1.29, <1.2.0-0` deployer range below could only resolve **1.1.29** — the last release before `ManifestEnvironment::default_bundle` existed. So the operator embedded a manifest parser one release behind the CLI it mirrors.

That is not a cosmetic gap: **`gtc op` routes to this binary**, so the whole `gtc` porcelain was affected, not just `greentic-operator`. The workaround was to call `greentic-deployer op env apply` directly.

Bumping the version alone would not have fixed it.

## Change

Both floors move together, exactly as the comments in this file already require ("the two floors move together"):

| dep | before | after | why |
|---|---|---|---|
| `greentic-deploy-spec` | `=0.2.5` | `=0.2.6` | adds `UpdateHostConfig::default_bundle` (`FieldUpdate<BundleId>`) + its `apply_to` — the settable half of greentic-deployer#521 |
| `greentic-deployer` | `>=1.1.29` | `>=1.1.30` | first publish declaring `=0.2.6`; also the one carrying `ManifestEnvironment::default_bundle` |

Diffed the two `.crate` tarballs to confirm 0.2.5 → 0.2.6 is purely additive: one new field on `UpdateHostConfig`, one `apply_to` call, no removals.

**The pin stays EXACT.** crates.io reports a dev-lane run-id build (`0.2.30193933262`) as this crate's `max_stable_version`, and a `<0.3` range would admit it — dragging in `greentic-types >=1.2.0-dev` against this crate's stable types pin. Comment updated to say so, since anyone raising this pin from the crates.io UI would otherwise pick the run-id.

## Verification

`op env apply --answers` on a manifest declaring `default_bundle`, built from this branch, now produces the same 7-step plan as `greentic-deployer op env apply`:

```
plan (7 step(s)):
  ensure-environment     local     create  env init (local bootstrap: default env-pack bindings + trust-root seed)
  update-host-config     local     create  set host-config on fresh env
  bootstrap-trust-root   local     create  bootstrap (fresh env)
  deploy-bundle          acct      create  sha256:376852c8 → default binding
  deploy-bundle          legal     create  sha256:bc57d02a → default binding
  deploy-bundle          support   create  sha256:01c58b85 → default binding
  deploy-bundle          gui       create  sha256:867e31a7 → default binding
```

| check | result |
|---|---|
| `bash ci/local_check.sh` | **exit 0** |
| tests | **265 passed, 0 failed** |
| `Cargo.lock` | moves exactly `greentic-deploy-spec` 0.2.5→0.2.6, `greentic-deployer` 1.1.29→1.1.30, and this crate's own version |

Root version bumped 1.1.4 → 1.1.5 in the same commit, so `Tag on Version Bump` cuts `v1.1.5` on merge and `release-binaries.yml` publishes it.

Part of the stalled multi-bundle-webchat release train: `greentic-setup` 1.1.26, `greentic-start` 1.1.29, this, and `gtc` 1.1.11.
